### PR TITLE
Add Embedding Delta v2 adapter and tooling

### DIFF
--- a/models/wan/embdelta_adapter.py
+++ b/models/wan/embdelta_adapter.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from typing import List, Tuple
+
+
+class EmbDeltaAdapter(nn.Module):
+    """
+    Token-level residual projector that:
+      - projects (low rank) + orthogonalizes delta w.r.t. base token embedding
+      - caps per-token delta norm
+      - applies a content-adaptive prompt-wise scalar gate in (0, 1)
+    Lives strictly between TE and DiT: E_out = E_in + g(prompt) * Δ(E_in)
+    """
+
+    def __init__(self, d_model: int, rank: int = 64, cap: float = 0.22):
+        super().__init__()
+        self.d_model = d_model
+        self.rank = rank
+        self.cap = cap
+
+        # Low-rank projector
+        self.ln = nn.LayerNorm(d_model, elementwise_affine=False)
+        self.down = nn.Linear(d_model, rank, bias=False)
+        self.up = nn.Linear(rank, d_model, bias=False)
+
+        # Prompt-wise gate: features = [pooled_emb, len_norm, token_var]
+        hidden = max(64, d_model // 32)
+        self.gate = nn.Sequential(
+            nn.Linear(d_model + 2, hidden), nn.SiLU(), nn.Linear(hidden, 1)
+        )
+
+    @torch.no_grad()
+    def _seq_mean(self, E: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        # E: [B, L, D], mask: [B, L]
+        m = mask.float().unsqueeze(-1)  # [B, L, 1]
+        denom = m.sum(dim=1).clamp_min(1.0)
+        return (E * m).sum(dim=1) / denom
+
+    def _prompt_gate(self, E: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        # Features: pooled embedding + (len_norm, token_var)
+        pooled = self._seq_mean(E, mask)  # [B, D]
+        len_norm = mask.sum(dim=1).float() / mask.size(1)  # [B]
+        # cheap statistic of within-prompt variance
+        m = mask.float().unsqueeze(-1)  # [B, L, 1]
+        centered = (E - pooled.unsqueeze(1)) * m
+        token_var = centered.pow(2).mean(dim=(1, 2))  # [B]
+
+        feats = torch.cat(
+            [pooled, len_norm.unsqueeze(-1), token_var.unsqueeze(-1)], dim=-1
+        )
+        gate = torch.sigmoid(self.gate(feats))  # [B, 1]
+        return gate  # (0,1)
+
+    def _orthogonalize(
+        self, delta: torch.Tensor, base: torch.Tensor, eps: float = 1e-6
+    ) -> torch.Tensor:
+        # Remove component of delta along base: Δ <- Δ - proj_base(Δ)
+        dot = (delta * base).sum(dim=-1, keepdim=True)
+        base_norm_sq = base.pow(2).sum(dim=-1, keepdim=True).clamp_min(eps)
+        return delta - (dot / base_norm_sq) * base
+
+    def forward(
+        self, E: torch.Tensor, mask: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        E:    [B, L, D], float
+        mask: [B, L],    bool/int
+        Returns (E_out, delta, gate) where:
+          E_out = E + gate * capped_orth_delta
+          delta = uncapped, pre-gated delta (for diagnostics)
+          gate  = [B, 1] content-adaptive scalar in (0,1)
+        """
+        assert E.ndim == 3, "E must be [B, L, D]"
+        assert mask.ndim == 2 and mask.shape[:1] == E.shape[:1], "mask must be [B, L]"
+
+        B, L, D = E.shape
+        assert D == self.d_model, f"d_model mismatch: got {D} vs {self.d_model}"
+
+        # Low-rank delta
+        Z = self.up(self.down(self.ln(E)))  # [B, L, D]
+        Z = self._orthogonalize(Z, E)  # geometry-preserving direction
+
+        # Per-token norm cap (soft)
+        # First squash with tanh to keep values tame, then cap by per-token L2
+        Z = torch.tanh(Z)
+        z_norm = Z.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+        scale = torch.clamp(self.cap / z_norm, max=1.0)
+        Z = Z * scale
+
+        # Prompt-wise gate in (0,1)
+        g = self._prompt_gate(E, mask).unsqueeze(1)  # [B,1,1]
+        E_out = E + g * Z
+
+        return E_out, Z, g.squeeze(-1)
+
+    # ---------- helper for list-of-tensors style ----------
+    @torch.no_grad()
+    def apply_on_list(
+        self, seqs: List[torch.Tensor], lens: torch.Tensor
+    ) -> List[torch.Tensor]:
+        """
+        seqs: list of [Li, D] float tensors (CPU/GPU ok)
+        lens: [B] lengths (int)
+        Returns list of same shapes, post-adapter.
+        """
+        device = seqs[0].device
+        B = len(seqs)
+        L = int(lens.max().item())
+        D = seqs[0].size(-1)
+
+        # pack to padded batch
+        E = torch.zeros(B, L, D, device=device, dtype=seqs[0].dtype)
+        mask = torch.zeros(B, L, dtype=torch.bool, device=device)
+        for i, t in enumerate(seqs):
+            li = int(lens[i].item())
+            E[i, :li] = t[:li]
+            mask[i, :li] = True
+
+        E_out, _, _ = self.forward(E, mask)
+
+        # unpack
+        out = []
+        for i in range(B):
+            li = int(lens[i].item())
+            out.append(E_out[i, :li].contiguous())
+        return out
+
+
+def load_embdelta_adapter(
+    path: str, d_model: int, map_location: str | torch.device = "cuda"
+) -> EmbDeltaAdapter:
+    ckpt = torch.load(path, map_location=map_location)
+    cfg = ckpt["config"]
+    model = EmbDeltaAdapter(d_model=cfg["d_model"], rank=cfg["rank"], cap=cfg["cap"])
+    model.load_state_dict(ckpt["state_dict"], strict=True)
+    model.eval().to(map_location)
+    return model
+
+
+# Optional convenience hook you can call from an inference script (no core edits):
+def apply_to_text_embeddings(
+    text_embeddings: List[torch.Tensor],
+    seq_lens: torch.Tensor,
+    adapter: EmbDeltaAdapter,
+) -> List[torch.Tensor]:
+    """
+    text_embeddings: list([Li, D]) from UMT5-XXL
+    seq_lens:        [B] lengths (int)
+    adapter:         loaded EmbDeltaAdapter
+    """
+    with torch.no_grad():
+        return adapter.apply_on_list(text_embeddings, seq_lens)

--- a/tools/embdelta_v2/README.md
+++ b/tools/embdelta_v2/README.md
@@ -1,0 +1,59 @@
+# Embedding Delta v2 (between TE and DiT)
+
+**Goal:** Learn a small residual adapter that adjusts UMT5‑XXL token embeddings *before* they reach Wan’s DiT, using ~750 `(base → rewritten)` prompts. No touching the encoder or the DiT.
+
+**Key ideas**
+- Low‑rank per‑token residual + **orthogonalization** to preserve encoder geometry
+- **Token‑wise norm cap** for stability
+- **Content‑adaptive prompt gate** (0–1) learned from pooled features for better gains on terse/single‑token prompts
+- Simple sequence‑level cosine objective vs. rewritten prompts + small geometry/magnitude regularizers
+
+**Outputs go to** `reports/embdelta_v2/*`.
+
+## Quickstart
+
+1. **Cache pairs (UMT5‑XXL encodings)**
+   ```bash
+   python tools/embdelta_v2/build_pairs_cache.py \
+     --jsonl datasets/nsfw_rewrites.jsonl \
+     --ckpt_root /workspace/models/Wan2.2-TI2V-5B \
+     --out reports/embdelta_v2/cache/pairs_5b_2.2.npz
+   ```
+
+2. **Train adapter**
+
+   ```bash
+   python tools/embdelta_v2/train_embdelta.py \
+     --cache reports/embdelta_v2/cache/pairs_5b_2.2.npz \
+     --out_dir reports/embdelta_v2/run1 \
+     --rank 64 --cap 0.22 --epochs 6000 --lr 3e-4 --batch_size 64
+   ```
+
+3. **Evaluate**
+
+   ```bash
+   python tools/embdelta_v2/eval_embdelta.py \
+     --cache reports/embdelta_v2/cache/pairs_5b_2.2.npz \
+     --adapter reports/embdelta_v2/run1/embdelta_adapter.pt \
+     --out_dir reports/embdelta_v2/run1/eval
+   ```
+
+4. **Use at inference (example)**
+
+   ```python
+   # Get token embeddings from your UMT5-XXL as usual:
+   ids, mask = t5.tokenizer([prompt], return_mask=True, add_special_tokens=True)
+   seq_lens  = mask.gt(0).sum(dim=1).long()
+   embs      = t5.model(ids.to(device), mask.to(device))  # list([Li, D])
+
+   # Load adapter and apply:
+   from models.wan.embdelta_adapter import load_embdelta_adapter, apply_to_text_embeddings
+   adapter = load_embdelta_adapter("reports/embdelta_v2/run1/embdelta_adapter.pt", d_model=embs[0].size(-1), map_location=device)
+   adj_embs = apply_to_text_embeddings(embs, seq_lens.to(device), adapter)
+   # Feed adj_embs to the rest of your pipeline in place of TE outputs.
+   ```
+
+**Notes**
+
+* Keep `cache_text_embeddings = False` if you integrate into a training/inference pipeline that would otherwise bypass the TE call. The adapter must see token embeddings at runtime.
+* All scripts write reports/artifacts under `reports/embdelta_v2/*`.

--- a/tools/embdelta_v2/build_pairs_cache.py
+++ b/tools/embdelta_v2/build_pairs_cache.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+# Make repo importable from tools/*
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from models.wan.t5 import T5EncoderModel  # noqa: E402
+from models.wan import configs as wan_configs  # noqa: E402
+from tools.embdelta_v2.utils_io import read_jsonl, ensure_dir  # noqa: E402
+
+
+@torch.no_grad()
+def encode_batch(te: T5EncoderModel, texts: list[str], device: torch.device):
+    # Match Wan pipeline: add_special_tokens=True, return mask
+    ids, mask = te.tokenizer(texts, return_mask=True, add_special_tokens=True)
+    ids = ids.to(device)
+    mask = mask.to(device)
+    lens = mask.gt(0).sum(dim=1).long()
+    embs = te.model(ids, mask)  # list of [Li, D] tensors
+    D = embs[0].size(-1)
+    L = int(mask.size(1))
+    B = len(embs)
+
+    # pack to padded for saving
+    E = torch.zeros(B, L, D, device=device, dtype=embs[0].dtype)
+    M = torch.zeros(B, L, device=device, dtype=torch.bool)
+    for i, (e, length) in enumerate(zip(embs, lens)):
+        li = int(length.item())
+        E[i, :li] = e[:li]
+        M[i, :li] = True
+    return E.cpu().numpy(), M.cpu().numpy(), lens.cpu().numpy()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--jsonl", required=True, help="JSONL with fields base_prompt, rewritten_prompt"
+    )
+    ap.add_argument("--ckpt_root", required=True, help="Path to Wan 2.2 5B (TI2V) root")
+    ap.add_argument("--out", default="reports/embdelta_v2/cache/pairs_5b_2.2.npz")
+    ap.add_argument("--batch_size", type=int, default=32)
+    ap.add_argument("--device", default="cuda")
+    args = ap.parse_args()
+
+    pairs = read_jsonl(args.jsonl)
+    base_prompts = [p["base_prompt"] for p in pairs]
+    rew_prompts = [p["rewritten_prompt"] for p in pairs]
+
+    # Resolve UMT5 paths via Wan config (TI2V_5B)
+    ckpt_dir = Path(args.ckpt_root)
+    wan_cfg = wan_configs.ti2v_5B
+    t5_path = ckpt_dir / wan_cfg.t5_checkpoint
+    tok_path = ckpt_dir / wan_cfg.t5_tokenizer
+
+    device = torch.device(args.device if torch.cuda.is_available() else "cpu")
+    te = T5EncoderModel(
+        text_len=wan_cfg.text_len,
+        dtype=torch.bfloat16,
+        device=device,
+        checkpoint_path=t5_path,
+        tokenizer_path=tok_path,
+        shard_fn=None,
+    )
+    te.model.eval()
+
+    # Encode in mini-batches
+    all_base_E, all_base_M, all_base_lens = [], [], []
+    all_rew_E, all_rew_M, all_rew_lens = [], [], []
+
+    bs = args.batch_size
+    for i in range(0, len(base_prompts), bs):
+        chunk = base_prompts[i : i + bs]
+        E, M, L = encode_batch(te, chunk, device)
+        all_base_E.append(E)
+        all_base_M.append(M)
+        all_base_lens.append(L)
+
+    for i in range(0, len(rew_prompts), bs):
+        chunk = rew_prompts[i : i + bs]
+        E, M, L = encode_batch(te, chunk, device)
+        all_rew_E.append(E)
+        all_rew_M.append(M)
+        all_rew_lens.append(L)
+
+    base_E = np.concatenate(all_base_E, axis=0)
+    base_M = np.concatenate(all_base_M, axis=0)
+    base_L = np.concatenate(all_base_lens, axis=0)
+    rew_E = np.concatenate(all_rew_E, axis=0)
+    rew_M = np.concatenate(all_rew_M, axis=0)
+    rew_L = np.concatenate(all_rew_lens, axis=0)
+
+    out_path = Path(args.out)
+    ensure_dir(out_path.parent)
+    np.savez_compressed(
+        out_path,
+        base_E=base_E,
+        base_M=base_M,
+        base_L=base_L,
+        rew_E=rew_E,
+        rew_M=rew_M,
+        rew_L=rew_L,
+    )
+    print(
+        f"Saved cache: {out_path}  "
+        f"(N={base_E.shape[0]}, L={base_E.shape[1]}, D={base_E.shape[2]})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/embdelta_v2/eval_embdelta.py
+++ b/tools/embdelta_v2/eval_embdelta.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from tools.embdelta_v2.model import EmbDeltaAdapter  # noqa: E402
+from tools.embdelta_v2.utils_io import ensure_dir  # noqa: E402
+
+
+def seq_mean(E, M):
+    m = M.float().unsqueeze(-1)
+    denom = m.sum(dim=1).clamp_min(1.0)
+    return (E * m).sum(dim=1) / denom
+
+
+@torch.no_grad()
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cache", required=True)
+    ap.add_argument("--adapter", required=True)
+    ap.add_argument("--out_dir", default="reports/embdelta_v2/eval")
+    ap.add_argument("--device", default="cuda")
+    args = ap.parse_args()
+
+    data = np.load(args.cache)
+    base_E = torch.from_numpy(data["base_E"]).to(torch.float32)
+    base_M = torch.from_numpy(data["base_M"]).bool()
+    rew_E = torch.from_numpy(data["rew_E"]).to(torch.float32)
+    rew_M = torch.from_numpy(data["rew_M"]).bool()
+    N, L, D = base_E.shape
+
+    device = torch.device(args.device if torch.cuda.is_available() else "cpu")
+    ckpt = torch.load(args.adapter, map_location=device)
+    model = EmbDeltaAdapter(
+        d_model=ckpt["config"]["d_model"],
+        rank=ckpt["config"]["rank"],
+        cap=ckpt["config"]["cap"],
+    ).to(device)
+    model.load_state_dict(ckpt["state_dict"], strict=True)
+    model.eval()
+
+    # batched eval
+    bs = 64
+    base_cos_list, new_cos_list = [], []
+    with torch.no_grad():
+        for i in range(0, N, bs):
+            E0 = base_E[i : i + bs].to(device)
+            M0 = base_M[i : i + bs].to(device)
+            E1 = rew_E[i : i + bs].to(device)
+            M1 = rew_M[i : i + bs].to(device)
+            Adj, _, _ = model(E0, M0)
+            base_cos_list.append(
+                F.cosine_similarity(seq_mean(E0, M0), seq_mean(E1, M1), dim=-1).cpu()
+            )
+            new_cos_list.append(
+                F.cosine_similarity(seq_mean(Adj, M0), seq_mean(E1, M1), dim=-1).cpu()
+            )
+
+    base_cos = torch.cat(base_cos_list)
+    new_cos = torch.cat(new_cos_list)
+    uplift = (new_cos - base_cos).numpy()
+
+    out_dir = ensure_dir(args.out_dir)
+    # histogram of uplift
+    plt.figure()
+    plt.hist(uplift, bins=40)
+    plt.title("Prompt-level cosine uplift (new - base)")
+    plt.xlabel("Δcos")
+    plt.ylabel("count")
+    plt.tight_layout()
+    plt.savefig(out_dir / "hist_prompt_uplift.png")
+    plt.close()
+
+    summary = {
+        "N": int(N),
+        "L": int(L),
+        "D": int(D),
+        "adapter_path": str(Path(args.adapter).resolve()),
+        "mean_uplift": float(uplift.mean()),
+        "p50_uplift": float(np.quantile(uplift, 0.5)),
+        "p90_uplift": float(np.quantile(uplift, 0.9)),
+        "mean_base_cos": float(base_cos.mean().item()),
+        "mean_new_cos": float(new_cos.mean().item()),
+    }
+    with (out_dir / "summary.json").open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    print(json.dumps(summary, indent=2))
+    print(f"Artifacts written under: {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/embdelta_v2/model.py
+++ b/tools/embdelta_v2/model.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class EmbDeltaAdapter(nn.Module):
+    def __init__(self, d_model: int, rank: int = 64, cap: float = 0.22):
+        super().__init__()
+        self.d_model = d_model
+        self.rank = rank
+        self.cap = cap
+
+        self.ln = nn.LayerNorm(d_model, elementwise_affine=False)
+        self.down = nn.Linear(d_model, rank, bias=False)
+        self.up = nn.Linear(rank, d_model, bias=False)
+
+        hidden = max(64, d_model // 32)
+        self.gate = nn.Sequential(
+            nn.Linear(d_model + 2, hidden), nn.SiLU(), nn.Linear(hidden, 1)
+        )
+
+    def _seq_mean(self, E: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        m = mask.float().unsqueeze(-1)
+        denom = m.sum(dim=1).clamp_min(1.0)
+        return (E * m).sum(dim=1) / denom
+
+    def _prompt_gate(self, E: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        pooled = self._seq_mean(E, mask)  # [B, D]
+        len_norm = mask.sum(dim=1).float() / mask.size(1)  # [B]
+        centered = (E - pooled.unsqueeze(1)) * mask.float().unsqueeze(-1)
+        token_var = centered.pow(2).mean(dim=(1, 2))  # [B]
+        feats = torch.cat(
+            [pooled, len_norm.unsqueeze(-1), token_var.unsqueeze(-1)], dim=-1
+        )
+        return torch.sigmoid(self.gate(feats))  # [B, 1]
+
+    def _orth(
+        self, delta: torch.Tensor, base: torch.Tensor, eps: float = 1e-6
+    ) -> torch.Tensor:
+        dot = (delta * base).sum(dim=-1, keepdim=True)
+        base_norm_sq = base.pow(2).sum(dim=-1, keepdim=True).clamp_min(eps)
+        return delta - (dot / base_norm_sq) * base
+
+    def forward(self, E: torch.Tensor, mask: torch.Tensor):
+        Z = self.up(self.down(self.ln(E)))  # [B, L, D]
+        Z = self._orth(Z, E)
+        Z = torch.tanh(Z)
+        z_norm = Z.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+        Z = Z * torch.clamp(self.cap / z_norm, max=1.0)
+
+        g = self._prompt_gate(E, mask).unsqueeze(1)  # [B,1,1]
+        E_out = E + g * Z
+        return E_out, Z, g

--- a/tools/embdelta_v2/train_embdelta.py
+++ b/tools/embdelta_v2/train_embdelta.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, Dataset, random_split
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from tools.embdelta_v2.model import EmbDeltaAdapter  # noqa: E402
+from tools.embdelta_v2.utils_io import ensure_dir  # noqa: E402
+
+
+class PairCache(Dataset):
+    def __init__(self, npz_path: str):
+        data = np.load(npz_path)
+        self.base_E = torch.from_numpy(data["base_E"])  # [N, L, D], float16
+        self.base_M = torch.from_numpy(data["base_M"])  # [N, L], bool
+        self.rew_E = torch.from_numpy(data["rew_E"])
+        self.rew_M = torch.from_numpy(data["rew_M"])
+        assert self.base_E.shape == self.rew_E.shape
+        self.N, self.L, self.D = self.base_E.shape
+        # promote dtype for training stability
+        self.base_E = self.base_E.to(torch.float32)
+        self.rew_E = self.rew_E.to(torch.float32)
+
+    def __len__(self):
+        return self.N
+
+    def __getitem__(self, i):
+        return (self.base_E[i], self.base_M[i], self.rew_E[i], self.rew_M[i])
+
+
+def seq_mean(E, M):
+    m = M.float().unsqueeze(-1)
+    denom = m.sum(dim=1).clamp_min(1.0)
+    return (E * m).sum(dim=1) / denom
+
+
+def train_one_epoch(model, loader, opt, device, w_anchor, w_orth, w_l2):
+    model.train()
+    total = 0.0
+    for base_E, base_M, rew_E, rew_M in loader:
+        base_E, base_M = base_E.to(device), base_M.to(device)
+        rew_E, rew_M = rew_E.to(device), rew_M.to(device)
+
+        adj_E, delta, gate = model(base_E, base_M)
+
+        # Main objective: align pooled embedding with rewritten pooled embedding
+        pooled_adj = seq_mean(adj_E, base_M)
+        pooled_rew = seq_mean(rew_E, rew_M)
+        loss_align = 1.0 - F.cosine_similarity(pooled_adj, pooled_rew, dim=-1).mean()
+
+        # Small anchor to keep adjusted close to base pooled geometry (stability)
+        pooled_base = seq_mean(base_E, base_M)
+        loss_anchor = (
+            1.0 - F.cosine_similarity(pooled_adj, pooled_base, dim=-1)
+        ).mean()
+
+        # Orth penalty (should be small, we also explicitly orthogonalize)
+        dot = (delta * base_E).sum(dim=-1)
+        base_n = base_E.norm(dim=-1).clamp_min(1e-6)
+        delta_n = delta.norm(dim=-1).clamp_min(1e-6)
+        loss_orth = (
+            (dot / (base_n * delta_n)) ** 2 * base_M.float()
+        ).sum() / base_M.float().sum().clamp_min(1.0)
+
+        # Small L2 on delta
+        loss_l2 = (
+            delta.pow(2).sum(dim=-1) * base_M.float()
+        ).sum() / base_M.float().sum().clamp_min(1.0)
+
+        loss = loss_align + w_anchor * loss_anchor + w_orth * loss_orth + w_l2 * loss_l2
+
+        opt.zero_grad(set_to_none=True)
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+        opt.step()
+        total += float(loss.item())
+    return total / len(loader)
+
+
+@torch.no_grad()
+def evaluate(model, loader, device):
+    model.eval()
+    base_cos, new_cos = [], []
+    for base_E, base_M, rew_E, rew_M in loader:
+        base_E, base_M = base_E.to(device), base_M.to(device)
+        rew_E, rew_M = rew_E.to(device), rew_M.to(device)
+        adj_E, _, _ = model(base_E, base_M)
+
+        pooled_rew = seq_mean(rew_E, rew_M)
+        pooled_base = seq_mean(base_E, base_M)
+        pooled_adj = seq_mean(adj_E, base_M)
+
+        base_cos.append(F.cosine_similarity(pooled_base, pooled_rew, dim=-1))
+        new_cos.append(F.cosine_similarity(pooled_adj, pooled_rew, dim=-1))
+
+    base_cos = torch.cat(base_cos)
+    new_cos = torch.cat(new_cos)
+    delta = new_cos - base_cos
+    return {
+        "mean_uplift": float(delta.mean().item()),
+        "p50_uplift": float(delta.median().item()),
+        "p90_uplift": float(delta.quantile(0.9).item()),
+        "mean_base_cos": float(base_cos.mean().item()),
+        "mean_new_cos": float(new_cos.mean().item()),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cache", required=True, help="NPZ from build_pairs_cache.py")
+    ap.add_argument("--out_dir", default="reports/embdelta_v2/run")
+    ap.add_argument("--rank", type=int, default=64)
+    ap.add_argument("--cap", type=float, default=0.22)
+    ap.add_argument("--batch_size", type=int, default=64)
+    ap.add_argument("--epochs", type=int, default=6000)
+    ap.add_argument("--lr", type=float, default=3e-4)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--val_frac", type=float, default=0.15)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--w_anchor", type=float, default=0.05)
+    ap.add_argument("--w_orth", type=float, default=0.02)
+    ap.add_argument("--w_l2", type=float, default=1e-4)
+    args = ap.parse_args()
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+
+    ds = PairCache(args.cache)
+    N_val = max(1, int(len(ds) * args.val_frac))
+    N_tr = len(ds) - N_val
+    tr_ds, va_ds = random_split(
+        ds, [N_tr, N_val], generator=torch.Generator().manual_seed(args.seed)
+    )
+
+    tr_ld = DataLoader(tr_ds, batch_size=args.batch_size, shuffle=True, drop_last=False)
+    va_ld = DataLoader(
+        va_ds, batch_size=args.batch_size, shuffle=False, drop_last=False
+    )
+
+    device = torch.device(args.device if torch.cuda.is_available() else "cpu")
+    model = EmbDeltaAdapter(d_model=ds.D, rank=args.rank, cap=args.cap).to(device)
+    opt = torch.optim.AdamW(
+        model.parameters(), lr=args.lr, betas=(0.9, 0.99), weight_decay=0.01
+    )
+
+    out_root = ensure_dir(Path(args.out_dir))
+    best_uplift, best_path = -1e9, None
+    log = []
+
+    for step in range(1, args.epochs + 1):
+        tr_loss = train_one_epoch(
+            model, tr_ld, opt, device, args.w_anchor, args.w_orth, args.w_l2
+        )
+        metrics = evaluate(model, va_ld, device)
+        metrics.update({"step": step, "train_loss": tr_loss})
+        log.append(metrics)
+        if step % 50 == 0:
+            print(
+                f"[{step}] loss={tr_loss:.4f}  uplift(mean/p50/p90)={metrics['mean_uplift']:.4f}/"
+                f"{metrics['p50_uplift']:.4f}/{metrics['p90_uplift']:.4f}  "
+                f"base={metrics['mean_base_cos']:.4f} new={metrics['mean_new_cos']:.4f}"
+            )
+
+        if metrics["mean_uplift"] > best_uplift:
+            best_uplift = metrics["mean_uplift"]
+            # save
+            ck = {
+                "config": {"d_model": ds.D, "rank": args.rank, "cap": args.cap},
+                "state_dict": model.state_dict(),
+                "metrics": metrics,
+            }
+            best_path = out_root / "embdelta_adapter.pt"
+            torch.save(ck, best_path)
+
+    with (out_root / "train_log.json").open("w", encoding="utf-8") as f:
+        json.dump(log, f, indent=2)
+    print(f"Best adapter saved to: {best_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/embdelta_v2/utils_io.py
+++ b/tools/embdelta_v2/utils_io.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+
+
+def read_jsonl(path: str | Path) -> List[Dict[str, Any]]:
+    path = Path(path)
+    out = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            out.append(json.loads(line))
+    return out
+
+
+def ensure_dir(p: str | Path) -> Path:
+    p = Path(p)
+    p.mkdir(parents=True, exist_ok=True)
+    return p


### PR DESCRIPTION
## Summary
- add `EmbDeltaAdapter` module that adjusts token embeddings between the text encoder and DiT
- introduce `tools/embdelta_v2` with cache builder, training, and evaluation scripts writing to `reports/`

## Testing
- `ruff check models/wan/embdelta_adapter.py tools/embdelta_v2`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9024d2eac832390a6bcde86495179