### PR TITLE
Handle PathLike checkpoints and enforce fp32 embeddings

### DIFF
--- a/tools/embdelta_v2/README.md
+++ b/tools/embdelta_v2/README.md
@@ -23,7 +23,7 @@
 2. **Train adapter**
 
    ```bash
-   python tools/embdelta_v2/train_embdelta.py \
+   python tools/embdelta_v2/train_emb_delta.py \
      --cache reports/embdelta_v2/cache/pairs_5b_2.2.npz \
      --out_dir reports/embdelta_v2/run1 \
      --rank 64 --cap 0.22 --epochs 6000 --lr 3e-4 --batch_size 64
@@ -32,7 +32,7 @@
 3. **Evaluate**
 
    ```bash
-   python tools/embdelta_v2/eval_embdelta.py \
+   python tools/embdelta_v2/eval_emb_delta.py \
      --cache reports/embdelta_v2/cache/pairs_5b_2.2.npz \
      --adapter reports/embdelta_v2/run1/embdelta_adapter.pt \
      --out_dir reports/embdelta_v2/run1/eval


### PR DESCRIPTION
## Summary
- Preserve encoder native dtype and cast outputs to float32 before NumPy conversion when building pairs cache
- Load cached arrays as float32 in training and eval helpers
- Refresh embdelta docs and scripts after rename

## Testing
- `black tools/embdelta_v2/build_pairs_cache.py tools/embdelta_v2/train_emb_delta.py tools/embdelta_v2/eval_emb_delta.py`
- `ruff check tools/embdelta_v2/build_pairs_cache.py tools/embdelta_v2/train_emb_delta.py tools/embdelta_v2/eval_emb_delta.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a91aa369b483238874ce2eee6ebfeb