### PR TITLE
Add MythoMax-to-Wan bridge training scaffold

### DIFF
--- a/bridge/adapter.py
+++ b/bridge/adapter.py
@@ -1,0 +1,92 @@
+import math
+import torch
+import torch.nn as nn
+
+
+class MLP(nn.Module):
+    def __init__(self, d, mult: int = 4, act: type[nn.Module] = nn.GELU):
+        super().__init__()
+        self.fc1 = nn.Linear(d, int(mult * d))
+        self.act = act()
+        self.fc2 = nn.Linear(int(mult * d), d)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.act(self.fc1(x)))
+
+
+class CrossBlock(nn.Module):
+    """Cross-attend learned queries (Lw × dm) to LLM tokens (Lt × dm), then MLP."""
+
+    def __init__(
+        self, d_model: int, n_heads: int, mlp_mult: int = 4, dropout: float = 0.0
+    ):
+        super().__init__()
+        self.q_ln = nn.LayerNorm(d_model)
+        self.kv_ln = nn.LayerNorm(d_model)
+        self.mha = nn.MultiheadAttention(
+            embed_dim=d_model, num_heads=n_heads, dropout=dropout, batch_first=True
+        )
+        self.mlp_ln = nn.LayerNorm(d_model)
+        self.mlp = MLP(d_model, mult=mlp_mult)
+
+    def forward(
+        self,
+        queries: torch.Tensor,
+        tokens: torch.Tensor,
+        tokens_mask: torch.BoolTensor | None = None,
+    ) -> torch.Tensor:
+        # queries: [B, Lw, dm], tokens: [B, Lt, dm]
+        q = self.q_ln(queries)
+        kv = self.kv_ln(tokens)
+        attn_out, _ = self.mha(
+            q,
+            kv,
+            kv,
+            key_padding_mask=(~tokens_mask) if tokens_mask is not None else None,
+            need_weights=False,
+        )
+        x = queries + attn_out
+        x = x + self.mlp(self.mlp_ln(x))
+        return x
+
+
+class PerceiverBridge(nn.Module):
+    """
+    LLM last hidden states (B, Lt, d_llm)  →  Wan tokens (B, Lw, d_wan)
+    Perceiver-style: learned queries (Lw, dm) attend over LLM tokens; N cross blocks; final proj to d_wan.
+    """
+
+    def __init__(
+        self,
+        d_llm: int = 5120,
+        d_wan: int = 3072,
+        L_wan: int = 512,
+        d_mid: int = 1024,
+        n_heads: int = 16,
+        n_blocks: int = 3,
+    ):
+        super().__init__()
+        self.L_wan = L_wan
+        self.query = nn.Parameter(torch.randn(L_wan, d_mid) / math.sqrt(d_mid))
+        self.in_proj = nn.Linear(d_llm, d_mid)  # project LLM tokens to mid
+        self.blocks = nn.ModuleList(
+            [CrossBlock(d_mid, n_heads) for _ in range(n_blocks)]
+        )
+        self.out_ln = nn.LayerNorm(d_mid)
+        self.out_proj = nn.Linear(d_mid, d_wan)
+        # learned scale/shift to match Wan feature stats
+        self.out_scale = nn.Parameter(torch.ones(1, 1, d_wan))
+        self.out_shift = nn.Parameter(torch.zeros(1, 1, d_wan))
+
+    def forward(
+        self, llm_tokens: torch.Tensor, llm_mask: torch.BoolTensor | None = None
+    ) -> torch.Tensor:
+        # llm_tokens: [B, Lt, d_llm]
+        B, Lt, _ = llm_tokens.shape
+        x_tokens = self.in_proj(llm_tokens)  # [B, Lt, d_mid]
+        # expand learned queries for B
+        queries = self.query.unsqueeze(0).expand(B, -1, -1).contiguous()
+        for blk in self.blocks:
+            queries = blk(queries, x_tokens, tokens_mask=llm_mask)
+        h = self.out_proj(self.out_ln(queries))
+        return h * self.out_scale + self.out_shift  # [B, L_wan, d_wan]

--- a/bridge/data.py
+++ b/bridge/data.py
@@ -1,0 +1,28 @@
+import json
+import random
+from pathlib import Path
+from torch.utils.data import Dataset
+
+
+class CaptionsJSONL(Dataset):
+    def __init__(
+        self, jsonl_path: str | Path, min_chars: int = 1, max_chars: int | None = None
+    ):
+        self.recs: list[str] = []
+        with open(jsonl_path, "r", encoding="utf-8") as f:
+            for line in f:
+                rec = json.loads(line)
+                cap = rec.get("caption", "")
+                if not cap:
+                    continue
+                if max_chars and len(cap) > max_chars:
+                    continue
+                if len(cap) >= min_chars:
+                    self.recs.append(cap)
+        random.shuffle(self.recs)
+
+    def __len__(self) -> int:
+        return len(self.recs)
+
+    def __getitem__(self, idx: int) -> str:
+        return self.recs[idx]

--- a/bridge/teachers/wan_text_teacher_from_wan.py
+++ b/bridge/teachers/wan_text_teacher_from_wan.py
@@ -1,0 +1,59 @@
+import sys
+from pathlib import Path
+
+import torch
+
+# Ensure repo root is on sys.path to import models.wan.t5
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from models.wan.t5 import T5EncoderModel  # noqa: E402
+
+
+class WanTextTeacher(torch.nn.Module):
+    """Wraps Wan's UMT5 encoder to provide Wan-space tokens."""
+
+    def __init__(
+        self,
+        ckpt: str | Path = REPO_ROOT
+        / "models"
+        / "Wan2.2-TI2V-5B"
+        / "models_t5_umt5-xxl-enc-bf16.pth",
+        tok_dir: str | Path = REPO_ROOT
+        / "models"
+        / "Wan2.2-TI2V-5B"
+        / "google"
+        / "umt5-xxl",
+        L_wan: int = 512,
+        d_wan: int = 3072,
+        device: str = "cuda",
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> None:
+        super().__init__()
+        self.L_wan = L_wan
+        self.d_wan = d_wan
+        self.device = device
+        self.enc = T5EncoderModel(
+            text_len=L_wan,
+            dtype=dtype,
+            device=device,
+            checkpoint_path=str(ckpt),
+            tokenizer_path=str(tok_dir),
+            shard_fn=None,
+        )
+        self.requires_grad_(False)
+
+    @torch.no_grad()
+    def forward(self, captions: list[str]) -> tuple[torch.Tensor, torch.BoolTensor]:
+        outs = self.enc(captions, self.device)
+        B = len(outs)
+        h = torch.zeros(
+            B, self.L_wan, self.d_wan, dtype=torch.bfloat16, device=self.device
+        )
+        m = torch.zeros(B, self.L_wan, dtype=torch.bool, device=self.device)
+        for i, t in enumerate(outs):
+            L = min(t.shape[0], self.L_wan)
+            h[i, :L, :] = t[:L].to(h.dtype).to(h.device)
+            m[i, :L] = True
+        return h, m

--- a/bridge/train_bridge.py
+++ b/bridge/train_bridge.py
@@ -1,0 +1,162 @@
+import argparse
+import os
+import random
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from adapter import PerceiverBridge
+from data import CaptionsJSONL
+from utils import cosine_loss, match_stats_loss, mse_loss, now
+from teachers.wan_text_teacher_from_wan import WanTextTeacher
+
+
+def seed_all(seed: int = 42) -> None:
+    random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def collate_text(batch: list[str]) -> list[str]:
+    return batch
+
+
+def get_llm_hidden(model, tok, texts, device: str):
+    with torch.no_grad():
+        enc = tok(
+            texts, return_tensors="pt", padding=True, truncation=True, max_length=4096
+        ).to(device)
+        out = model(**enc, output_hidden_states=True, use_cache=False)
+        h = out.hidden_states[-1]
+        mask = enc["attention_mask"].bool()
+    return h, mask
+
+
+def default_paths() -> tuple[Path, Path, Path]:
+    repo_root = Path(__file__).resolve().parents[1]
+    captions = repo_root / "data" / "captions.jsonl"
+    model_dir = repo_root / "models" / "MythoMax-L2-13B"
+    save_dir = repo_root / "checkpoints" / "bridge"
+    return captions, model_dir, save_dir
+
+
+def main() -> None:
+    captions_def, model_def, save_def = map(str, default_paths())
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--captions", default=captions_def)
+    ap.add_argument("--model_dir", default=model_def)
+    ap.add_argument("--save_dir", default=save_def)
+    ap.add_argument("--batch_size", type=int, default=4)
+    ap.add_argument("--epochs", type=int, default=2)
+    ap.add_argument("--lr", type=float, default=1e-4)
+    ap.add_argument("--adamw", type=float, default=0.01)
+    ap.add_argument("--warmup_steps", type=int, default=200)
+    ap.add_argument("--log_every", type=int, default=50)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--L_wan", type=int, default=512)
+    ap.add_argument("--d_wan", type=int, default=3072)
+    ap.add_argument("--teacher", choices=["wan", "none"], default="wan")
+    ap.add_argument("--d_mid", type=int, default=1024)
+    ap.add_argument("--n_blocks", type=int, default=3)
+    ap.add_argument("--heads_mid", type=int, default=16)
+    ap.add_argument("--fp16", action="store_true")
+    args = ap.parse_args()
+
+    seed_all(123)
+    os.makedirs(args.save_dir, exist_ok=True)
+
+    print(f"[{now()}] loading LLM from {args.model_dir}")
+    tok = AutoTokenizer.from_pretrained(args.model_dir, use_fast=True)
+    llm = AutoModelForCausalLM.from_pretrained(
+        args.model_dir,
+        torch_dtype=(
+            torch.bfloat16
+            if (torch.cuda.is_available() and not args.fp16)
+            else torch.float16
+        ),
+        device_map="auto",
+    )
+    llm.eval().requires_grad_(False)
+
+    bridge = PerceiverBridge(
+        d_llm=llm.config.hidden_size,
+        d_wan=args.d_wan,
+        L_wan=args.L_wan,
+        d_mid=args.d_mid,
+        n_heads=args.heads_mid,
+        n_blocks=args.n_blocks,
+    ).to(args.device)
+
+    teacher = None
+    if args.teacher == "wan":
+        teacher = WanTextTeacher(
+            L_wan=args.L_wan, d_wan=args.d_wan, device=args.device
+        ).to(args.device)
+        for p in teacher.parameters():
+            p.requires_grad = False
+        print(f"[{now()}] Using WAN teacher (real UMT5→Wan).")
+    else:
+        print(
+            f"[{now()}] No teacher; training with distribution/shape constraints only."
+        )
+
+    ds = CaptionsJSONL(args.captions, min_chars=1)
+    dl = DataLoader(
+        ds,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=2,
+        collate_fn=collate_text,
+        drop_last=True,
+    )
+
+    optim = torch.optim.AdamW(bridge.parameters(), lr=args.lr, weight_decay=args.adamw)
+    scaler = torch.cuda.amp.GradScaler(enabled=args.fp16)
+
+    global_step = 0
+    for epoch in range(args.epochs):
+        for batch_i, texts in enumerate(dl):
+            bridge.train()
+            llm_h, llm_mask = get_llm_hidden(llm, tok, texts, device=args.device)
+            with torch.cuda.amp.autocast(enabled=args.fp16):
+                h_hat = bridge(llm_h.to(args.device), llm_mask.to(args.device))
+                loss = 0.0
+                if teacher is not None:
+                    h_t, m_t = teacher(texts)
+                    loss_mse = mse_loss(h_hat, h_t, mask=m_t)
+                    loss_cos = cosine_loss(h_hat, h_t, mask=m_t)
+                    loss_stats = match_stats_loss(h_hat, h_t, mask=m_t)
+                    loss = loss + (1.0 * loss_mse + 0.5 * loss_cos + 0.1 * loss_stats)
+                else:
+                    mu = h_hat.mean(dim=(0, 1))
+                    sigma = h_hat.std(dim=(0, 1))
+                    loss = loss + 0.1 * (
+                        torch.abs(mu).mean() + torch.abs(sigma - 1.0).mean()
+                    )
+
+            optim.zero_grad(set_to_none=True)
+            scaler.scale(loss).backward()
+            torch.nn.utils.clip_grad_norm_(bridge.parameters(), 1.0)
+            scaler.step(optim)
+            scaler.update()
+
+            global_step += 1
+            if global_step % args.log_every == 0:
+                print(
+                    f"[{now()}] ep{epoch} it{batch_i} step{global_step} loss={loss.item():.4f}"
+                )
+
+        ckpt = {"bridge": bridge.state_dict(), "cfg": vars(args)}
+        if teacher is not None and hasattr(teacher, "proj"):
+            ckpt["teacher_proj"] = teacher.proj.state_dict()
+        outp = Path(args.save_dir) / f"bridge_epoch{epoch:02d}.pth"
+        torch.save(ckpt, outp)
+        print(f"[{now()}] saved {outp}")
+
+    print(f"[{now()}] done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bridge/utils.py
+++ b/bridge/utils.py
@@ -1,0 +1,48 @@
+import time
+import torch
+
+
+def cosine_loss(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    mask: torch.BoolTensor | None = None,
+    eps: float = 1e-8,
+) -> torch.Tensor:
+    # x,y: [B, L, D]; mask: [B, L] (bool)
+    x = torch.nn.functional.normalize(x, dim=-1)
+    y = torch.nn.functional.normalize(y, dim=-1)
+    if mask is not None:
+        m = mask.unsqueeze(-1).float()
+        return ((1.0 - (x * y).sum(dim=-1)) * m.squeeze(-1)).sum() / (m.sum() + 1e-8)
+    return (1.0 - (x * y).sum(dim=-1)).mean()
+
+
+def mse_loss(
+    x: torch.Tensor, y: torch.Tensor, mask: torch.BoolTensor | None = None
+) -> torch.Tensor:
+    if mask is not None:
+        m = mask.unsqueeze(-1).float()
+        return ((x - y) ** 2 * m).sum() / (m.sum() * x.shape[-1] + 1e-8)
+    return torch.nn.functional.mse_loss(x, y)
+
+
+def match_stats_loss(
+    x: torch.Tensor, y: torch.Tensor, mask: torch.BoolTensor | None = None
+) -> torch.Tensor:
+    # channel mean/var match; x,y: [B,L,D]
+    if mask is not None:
+        m = mask.unsqueeze(-1).float()
+        xm = (x * m).sum(dim=(0, 1)) / (m.sum(dim=(0, 1)) + 1e-8)
+        ym = (y * m).sum(dim=(0, 1)) / (m.sum(dim=(0, 1)) + 1e-8)
+        xv = (((x - xm) * m) ** 2).sum(dim=(0, 1)) / (m.sum(dim=(0, 1)) + 1e-8)
+        yv = (((y - ym) * m) ** 2).sum(dim=(0, 1)) / (m.sum(dim=(0, 1)) + 1e-8)
+    else:
+        xm, xv = x.mean(dim=(0, 1)), x.var(dim=(0, 1), unbiased=False)
+        ym, yv = y.mean(dim=(0, 1)), y.var(dim=(0, 1), unbiased=False)
+    return torch.nn.functional.l1_loss(xm, ym) + torch.nn.functional.l1_loss(
+        torch.sqrt(xv + 1e-8), torch.sqrt(yv + 1e-8)
+    )
+
+
+def now() -> str:
+    return time.strftime("%Y-%m-%d %H:%M:%S")

--- a/models/wan/bridges/__init__.py
+++ b/models/wan/bridges/__init__.py
@@ -1,0 +1,3 @@
+from .mythomax import MythoMaxBridgeEncoder
+
+__all__ = ["MythoMaxBridgeEncoder"]

--- a/models/wan/bridges/mythomax.py
+++ b/models/wan/bridges/mythomax.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from bridge.adapter import PerceiverBridge
+
+
+class MythoMaxBridgeEncoder:
+    """Map MythoMax-L2-13B hidden states to Wan's token space using a trained Perceiver bridge."""
+
+    def __init__(
+        self,
+        text_len: int = 512,
+        d_wan: int = 3072,
+        llm_dir: str | Path = Path(__file__).resolve().parents[3]
+        / "models"
+        / "MythoMax-L2-13B",
+        bridge_ckpt: str | Path = Path(__file__).resolve().parents[3]
+        / "checkpoints"
+        / "bridge"
+        / "bridge_epoch01.pth",
+        d_mid: int = 1024,
+        n_blocks: int = 3,
+        heads_mid: int = 16,
+        dtype: torch.dtype = torch.bfloat16,
+        device: int | str = torch.cuda.current_device(),
+    ) -> None:
+        self.text_len = text_len
+        self.d_wan = d_wan
+        self.device = device
+        self.dtype = dtype
+
+        self.tok = AutoTokenizer.from_pretrained(str(llm_dir), use_fast=True)
+        self.llm = AutoModelForCausalLM.from_pretrained(
+            str(llm_dir), torch_dtype=dtype, device_map="auto"
+        )
+        self.llm.eval().requires_grad_(False)
+        d_llm = self.llm.config.hidden_size
+
+        self.bridge = (
+            PerceiverBridge(
+                d_llm=d_llm,
+                d_wan=d_wan,
+                L_wan=text_len,
+                d_mid=d_mid,
+                n_heads=heads_mid,
+                n_blocks=n_blocks,
+            )
+            .to(device)
+            .eval()
+        )
+        ckpt = torch.load(str(bridge_ckpt), map_location="cpu")
+        self.bridge.load_state_dict(ckpt["bridge"], strict=True)
+
+    @torch.no_grad()
+    def __call__(
+        self, texts: list[str], device: int | str | None = None
+    ) -> list[torch.Tensor]:
+        device = device or self.device
+        enc = self.tok(
+            texts, return_tensors="pt", padding=True, truncation=True, max_length=4096
+        ).to(self.llm.device)
+        out = self.llm(**enc, output_hidden_states=True, use_cache=False)
+        h_llm = out.hidden_states[-1]
+        mask_llm = enc["attention_mask"].bool()
+        h_wan = self.bridge(h_llm, mask_llm)
+        lengths = mask_llm.sum(dim=1).clamp(max=self.text_len).tolist()
+        out_list: list[torch.Tensor] = []
+        for i, L in enumerate(lengths):
+            L = L if L > 0 else min(8, self.text_len)
+            out_list.append(h_wan[i, :L, :].to(device))
+        return out_list


### PR DESCRIPTION
## Summary
- add Perceiver-style bridge mapping MythoMax token states to Wan's 512×3072 space
- wire Wan UMT5 encoder as a frozen teacher for training
- introduce training script, dataset loader and utilities using repo paths
- extract MythoMax bridge into standalone module so `t5.py` stays model-agnostic

## Testing
- `black models/wan/t5.py models/wan/bridges/mythomax.py models/wan/bridges/__init__.py`
- `ruff check models/wan/t5.py models/wan/bridges/mythomax.py models/wan/bridges/__init__.py`
- `python -m py_compile models/wan/t5.py models/wan/bridges/mythomax.py models/wan/bridges/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad0fc4d9388323b87d6b766fcf5b00