### PR TITLE
Auto-detect Wan text interface dims

### DIFF
--- a/bridge/teachers/wan_text_teacher_from_wan.py
+++ b/bridge/teachers/wan_text_teacher_from_wan.py
@@ -26,13 +26,12 @@ class WanTextTeacher(torch.nn.Module):
         / "google"
         / "umt5-xxl",
         L_wan: int = 512,
-        d_wan: int = 3072,
+        d_wan: int | None = None,
         device: str = "cuda",
         dtype: torch.dtype = torch.bfloat16,
     ) -> None:
         super().__init__()
-        self.L_wan = L_wan
-        self.d_wan = d_wan
+        self.L_wan, self.d_wan = L_wan, d_wan
         self.device = device
         self.enc = T5EncoderModel(
             text_len=L_wan,
@@ -76,14 +75,21 @@ class WanTextTeacher(torch.nn.Module):
 
     @torch.no_grad()
     def forward(self, captions: list[str]) -> tuple[torch.Tensor, torch.BoolTensor]:
-        outs = self.enc(captions, self.device)
+        outs = self.enc(captions, self.device)  # list of [L_i, d_enc]
         B = len(outs)
+        if self.d_wan is None:
+            self.d_wan = outs[0].shape[1]
         h = torch.zeros(
             B, self.L_wan, self.d_wan, dtype=torch.bfloat16, device=self.device
         )
         m = torch.zeros(B, self.L_wan, dtype=torch.bool, device=self.device)
         for i, t in enumerate(outs):
             L = min(t.shape[0], self.L_wan)
+            D = t.shape[1]
+            if D != self.d_wan:
+                raise RuntimeError(
+                    f"WanTextTeacher width changed within a batch: got {D}, expected {self.d_wan}"
+                )
             h[i, :L, :] = t[:L].to(h.dtype).to(h.device)
             m[i, :L] = True
         return h, m

--- a/bridge/train_bridge.py
+++ b/bridge/train_bridge.py
@@ -80,6 +80,29 @@ def main() -> None:
     )
     llm.eval().requires_grad_(False)
 
+    teacher = None
+    if args.teacher == "wan":
+        teacher = WanTextTeacher(L_wan=args.L_wan, d_wan=None, device=args.device).to(
+            args.device
+        )
+        for p in teacher.parameters():
+            p.requires_grad = False
+        print(f"[{now()}] Using WAN teacher (real UMT5→Wan).")
+    else:
+        print(
+            f"[{now()}] No teacher; training with distribution/shape constraints only."
+        )
+
+    if teacher is not None:
+        with torch.no_grad():
+            h_probe, _ = teacher(["."])
+        auto_L, auto_D = h_probe.shape[1], h_probe.shape[2]
+        if args.L_wan != auto_L or args.d_wan != auto_D:
+            print(
+                f"[{now()}] Auto-detected Wan text interface: L={auto_L}, D={auto_D} (overriding CLI defaults)"
+            )
+            args.L_wan, args.d_wan = int(auto_L), int(auto_D)
+
     bridge = PerceiverBridge(
         d_llm=llm.config.hidden_size,
         d_wan=args.d_wan,
@@ -88,19 +111,6 @@ def main() -> None:
         n_heads=args.heads_mid,
         n_blocks=args.n_blocks,
     ).to(args.device)
-
-    teacher = None
-    if args.teacher == "wan":
-        teacher = WanTextTeacher(
-            L_wan=args.L_wan, d_wan=args.d_wan, device=args.device
-        ).to(args.device)
-        for p in teacher.parameters():
-            p.requires_grad = False
-        print(f"[{now()}] Using WAN teacher (real UMT5→Wan).")
-    else:
-        print(
-            f"[{now()}] No teacher; training with distribution/shape constraints only."
-        )
 
     ds = CaptionsJSONL(args.captions, min_chars=1)
     dl = DataLoader(
@@ -113,14 +123,15 @@ def main() -> None:
     )
 
     optim = torch.optim.AdamW(bridge.parameters(), lr=args.lr, weight_decay=args.adamw)
-    scaler = torch.cuda.amp.GradScaler(enabled=args.fp16)
+    scaler = torch.amp.GradScaler("cuda") if args.fp16 else None
+    autocast_dtype = torch.float16 if args.fp16 else torch.bfloat16
 
     global_step = 0
     for epoch in range(args.epochs):
         for batch_i, texts in enumerate(dl):
             bridge.train()
             llm_h, llm_mask = get_llm_hidden(llm, tok, texts, device=args.device)
-            with torch.cuda.amp.autocast(enabled=args.fp16):
+            with torch.amp.autocast("cuda", dtype=autocast_dtype):
                 h_hat = bridge(llm_h.to(args.device), llm_mask.to(args.device))
                 loss = 0.0
                 if teacher is not None:
@@ -137,10 +148,15 @@ def main() -> None:
                     )
 
             optim.zero_grad(set_to_none=True)
-            scaler.scale(loss).backward()
-            torch.nn.utils.clip_grad_norm_(bridge.parameters(), 1.0)
-            scaler.step(optim)
-            scaler.update()
+            if scaler is not None:
+                scaler.scale(loss).backward()
+                torch.nn.utils.clip_grad_norm_(bridge.parameters(), 1.0)
+                scaler.step(optim)
+                scaler.update()
+            else:
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_(bridge.parameters(), 1.0)
+                optim.step()
 
             global_step += 1
             if global_step % args.log_every == 0:

--- a/models/wan/bridges/mythomax.py
+++ b/models/wan/bridges/mythomax.py
@@ -13,8 +13,6 @@ class MythoMaxBridgeEncoder:
 
     def __init__(
         self,
-        text_len: int = 512,
-        d_wan: int = 3072,
         llm_dir: str | Path = Path(__file__).resolve().parents[3]
         / "models"
         / "MythoMax-L2-13B",
@@ -28,8 +26,6 @@ class MythoMaxBridgeEncoder:
         dtype: torch.dtype = torch.bfloat16,
         device: int | str = torch.cuda.current_device(),
     ) -> None:
-        self.text_len = text_len
-        self.d_wan = d_wan
         self.device = device
         self.dtype = dtype
 
@@ -40,11 +36,16 @@ class MythoMaxBridgeEncoder:
         self.llm.eval().requires_grad_(False)
         d_llm = self.llm.config.hidden_size
 
+        ckpt = torch.load(str(bridge_ckpt), map_location="cpu")
+        cfg = ckpt.get("cfg", {})
+        self.text_len = int(cfg.get("L_wan", 512))
+        self.d_wan = int(cfg.get("d_wan", 4096))
+
         self.bridge = (
             PerceiverBridge(
                 d_llm=d_llm,
-                d_wan=d_wan,
-                L_wan=text_len,
+                d_wan=self.d_wan,
+                L_wan=self.text_len,
                 d_mid=d_mid,
                 n_heads=heads_mid,
                 n_blocks=n_blocks,
@@ -52,7 +53,6 @@ class MythoMaxBridgeEncoder:
             .to(device)
             .eval()
         )
-        ckpt = torch.load(str(bridge_ckpt), map_location="cpu")
         self.bridge.load_state_dict(ckpt["bridge"], strict=True)
 
     @torch.no_grad()


### PR DESCRIPTION
## Summary
- Let `WanTextTeacher` discover token width on first forward pass and validate consistency
- Build bridge after probing the teacher to infer `L_wan`/`d_wan`; switch training to new `torch.amp` APIs
- Load `d_wan`/`L_wan` from bridge checkpoints at inference for `MythoMaxBridgeEncoder`

## Testing
- `ruff check bridge/teachers/wan_text_teacher_from_wan.py bridge/train_bridge.py models/wan/bridges/mythomax.py`
- `black bridge/teachers/wan_text_teacher_from_wan.py bridge/train_bridge.py models/wan/bridges/mythomax.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1cec9ff083238e2c39843c793bfe