### PR TITLE
feat: add bridge training and caching scripts

### DIFF
--- a/bridge/precache_features.py
+++ b/bridge/precache_features.py
@@ -1,0 +1,96 @@
+import argparse
+import json
+from pathlib import Path
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from teachers.wan_text_teacher_from_wan import WanTextTeacher
+
+
+def iter_captions(jsonl_path, start=0, count=0):
+    with open(jsonl_path, "r", encoding="utf-8") as f:
+        for i, line in enumerate(f):
+            if i < start:
+                continue
+            if count and (i - start) >= count:
+                break
+            j = json.loads(line)
+            cap = j.get("caption", "").strip()
+            if cap:
+                yield i, cap
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--captions", required=True)
+    ap.add_argument("--llm_dir", required=True)
+    ap.add_argument("--out_dir", required=True)
+    ap.add_argument("--shard_size", type=int, default=2048)
+    ap.add_argument("--start", type=int, default=0)
+    ap.add_argument("--count", type=int, default=0, help="0=all")
+    ap.add_argument("--llm_max_length", type=int, default=512)
+    ap.add_argument("--device", default="cuda")
+    args = ap.parse_args()
+
+    out = Path(args.out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    tok = AutoTokenizer.from_pretrained(args.llm_dir, use_fast=True)
+    llm = AutoModelForCausalLM.from_pretrained(
+        args.llm_dir, torch_dtype=torch.bfloat16, device_map="auto"
+    )
+    llm.eval().requires_grad_(False)
+
+    teacher = WanTextTeacher(L_wan=512, d_wan=None, device=args.device).eval()
+
+    buf_idx, buf_caps = [], []
+    shard_id, total = 0, 0
+
+    def flush():
+        nonlocal shard_id, total, buf_idx, buf_caps
+        if not buf_caps:
+            return
+        with torch.no_grad():
+            enc = tok(
+                buf_caps,
+                return_tensors="pt",
+                padding=True,
+                truncation=True,
+                max_length=args.llm_max_length,
+            ).to(llm.device)
+            out = llm(**enc, output_hidden_states=True, use_cache=False)
+            llm_h = out.hidden_states[-1].to(torch.bfloat16).cpu()  # [B, Lt, d_llm]
+            llm_msk = enc["attention_mask"].bool().cpu()
+
+            wan_h, wan_m = teacher(buf_caps)  # [B, 512, 4096], [B, 512]
+            wan_h = wan_h.to(torch.bfloat16).cpu()
+            wan_m = wan_m.cpu()
+
+        shard = {
+            "idx": buf_idx,
+            "captions": buf_caps,
+            "llm_h": llm_h,
+            "llm_mask": llm_msk,
+            "wan_h": wan_h,
+            "wan_mask": wan_m,
+        }
+        path = out / f"shard_{shard_id:05d}.pt"
+        torch.save(shard, path)
+        print(
+            f"[precache] wrote {path}  (n={len(buf_caps)}, total={total + len(buf_caps)})"
+        )
+        shard_id += 1
+        total += len(buf_caps)
+        buf_idx, buf_caps = [], []
+
+    for i, cap in iter_captions(args.captions, args.start, args.count):
+        buf_idx.append(i)
+        buf_caps.append(cap)
+        if len(buf_caps) >= args.shard_size:
+            flush()
+
+    flush()
+    print(f"[precache] done. total cached={total}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bridge/train_bridge.py
+++ b/bridge/train_bridge.py
@@ -1,13 +1,12 @@
-import os
 import argparse
+import os
 import random
+import signal
 from pathlib import Path
-
-os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 
 import torch
 from torch.utils.data import DataLoader
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoTokenizer, AutoModelForCausalLM
 
 from adapter import PerceiverBridge
 from data import CaptionsJSONL
@@ -22,40 +21,51 @@ from utils import (
     detect_anomaly_if,
 )
 
-
+# Teacher imports (Wan is preferred)
 try:
     from teachers.wan_text_teacher_from_wan import WanTextTeacher
-except Exception:  # pragma: no cover - optional dependency
+except Exception:
     WanTextTeacher = None
-
 try:
     from teachers.umt5_hf_projection import HFUMT5Teacher
-except Exception:  # pragma: no cover - optional dependency
+except Exception:
     HFUMT5Teacher = None
 
+# --- performance knobs: TF32 on A100 ---
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+try:
+    torch.set_float32_matmul_precision("high")
+except Exception:
+    pass
 
-def seed_all(seed: int = 42) -> None:
+
+def seed_all(seed=42):
     random.seed(seed)
     torch.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
 
 
-def collate_text(batch: list[str]) -> list[str]:
+def collate_text(batch):
     return batch
 
 
-def get_llm_hidden(model, tok, texts, device: str):
+def get_llm_hidden(model, tok, texts, device, llm_max_length):
     with torch.no_grad():
         enc = tok(
-            texts, return_tensors="pt", padding=True, truncation=True, max_length=4096
+            texts,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=llm_max_length,
         ).to(device)
         out = model(**enc, output_hidden_states=True, use_cache=False)
-        h = out.hidden_states[-1]
+        h = out.hidden_states[-1]  # [B, Lt, d_llm]
         mask = enc["attention_mask"].bool()
     return h, mask
 
 
-def build_autocast_and_scaler(amp_mode: str):
+def build_autocast_and_scaler(amp_mode):
     amp_mode = (amp_mode or "bf16").lower()
     if amp_mode == "fp16":
         autocast_cm = torch.amp.autocast("cuda", dtype=torch.float16)
@@ -63,42 +73,57 @@ def build_autocast_and_scaler(amp_mode: str):
     elif amp_mode == "bf16":
         autocast_cm = torch.amp.autocast("cuda", dtype=torch.bfloat16)
         scaler = None
-    else:
+    else:  # off
 
-        class _NullCtx:
+        class NullCtx:
             def __enter__(self):
                 return None
 
             def __exit__(self, *args):
                 return False
 
-        autocast_cm = _NullCtx()
-        scaler = None
+        autocast_cm, scaler = NullCtx(), None
     return autocast_cm, scaler, amp_mode
 
 
-def main() -> None:
+def main():
     ap = argparse.ArgumentParser()
+    # data / models
     ap.add_argument("--captions", default="/workspace/data/captions.jsonl")
     ap.add_argument("--model_dir", default="/workspace/models/MythoMax-L2-13B")
     ap.add_argument("--save_dir", default="/workspace/checkpoints/bridge")
-    ap.add_argument("--batch_size", type=int, default=4)
-    ap.add_argument("--epochs", type=int, default=2)
-    ap.add_argument("--lr", type=float, default=1e-4)
-    ap.add_argument("--adamw", type=float, default=0.01)
-    ap.add_argument("--warmup_steps", type=int, default=200)
-    ap.add_argument("--log_every", type=int, default=50)
-    ap.add_argument("--device", default="cuda")
-    ap.add_argument("--L_wan", type=int, default=512)
-    ap.add_argument("--d_wan", type=int, default=4096)
     ap.add_argument("--teacher", choices=["wan", "umt5_hf", "none"], default="wan")
     ap.add_argument("--teacher_hf_name", default="google/umt5-xxl")
+    # dims
+    ap.add_argument("--L_wan", type=int, default=512)
+    ap.add_argument(
+        "--d_wan", type=int, default=4096
+    )  # auto-overridden by teacher probe
     ap.add_argument("--d_mid", type=int, default=1024)
     ap.add_argument("--n_blocks", type=int, default=3)
     ap.add_argument("--heads_mid", type=int, default=16)
+    # training
+    ap.add_argument("--batch_size", type=int, default=8)
+    ap.add_argument("--grad_accum", type=int, default=1)
+    ap.add_argument("--epochs", type=int, default=1)
+    ap.add_argument(
+        "--max_steps", type=int, default=0, help="Stop after N steps (0=off)."
+    )
+    ap.add_argument("--lr", type=float, default=1e-4)
+    ap.add_argument("--adamw", type=float, default=0.01)
     ap.add_argument("--amp", choices=["bf16", "fp16", "off"], default="bf16")
+    ap.add_argument(
+        "--llm_max_length", type=int, default=512, help="LLM token cap (was 4096)."
+    )
+    ap.add_argument("--device", default="cuda")
+    # logging / saving
+    ap.add_argument("--log_every", type=int, default=50)
     ap.add_argument("--debug_log_name", default="bridge_debug.jsonl")
     ap.add_argument("--debug_dump_every", type=int, default=0)
+    ap.add_argument(
+        "--save_every_steps", type=int, default=1000, help="0=off; save every N steps."
+    )
+    ap.add_argument("--save_keep_last_k", type=int, default=5)
     ap.add_argument("--detect_anomaly_steps", type=int, default=2)
     args = ap.parse_args()
 
@@ -108,6 +133,17 @@ def main() -> None:
     dumps_dir = Path(args.save_dir) / "dumps"
     dumps_dir.mkdir(parents=True, exist_ok=True)
 
+    # support on-demand checkpointing via USR1
+    _save_now = {"flag": False}
+
+    def _sigusr1_handler(sig, frame):
+        _save_now["flag"] = True
+
+    try:
+        signal.signal(signal.SIGUSR1, _sigusr1_handler)
+    except Exception:
+        pass
+
     print(f"[{now()}] loading LLM from {args.model_dir}")
     tok = AutoTokenizer.from_pretrained(args.model_dir, use_fast=True)
     llm_dtype = torch.bfloat16 if args.amp != "off" else torch.float32
@@ -116,6 +152,7 @@ def main() -> None:
     )
     llm.eval().requires_grad_(False)
 
+    # Teacher
     teacher = None
     if args.teacher == "wan" and WanTextTeacher is not None:
         teacher = WanTextTeacher(L_wan=args.L_wan, d_wan=None, device=args.device).to(
@@ -123,7 +160,7 @@ def main() -> None:
         )
         for p in teacher.parameters():
             p.requires_grad = False
-        print(f"[{now()}] Using WAN teacher (real UMT5_Wan).")
+        print(f"[{now()}] Using WAN teacher (real UMT5).")
     elif args.teacher == "umt5_hf" and HFUMT5Teacher is not None:
         teacher = HFUMT5Teacher(
             hf_name=args.teacher_hf_name,
@@ -133,18 +170,20 @@ def main() -> None:
         ).to(args.device)
         print(f"[{now()}] Using HF UMT5 + proj teacher.")
     else:
-        print(f"[{now()}] No teacher; training with shape/stat constraints only.")
+        print(f"[{now()}] No teacher; distribution constraints only.")
 
+    # Auto-detect Wan dims from teacher
     if teacher is not None:
         with torch.no_grad():
             H_probe, M_probe = teacher(["."])
         auto_L, auto_D = int(H_probe.shape[1]), int(H_probe.shape[2])
         if args.L_wan != auto_L or args.d_wan != auto_D:
             print(
-                f"[{now()}] Auto-detected Wan text interface: L={auto_L}, D={auto_D} (overriding CLI defaults)"
+                f"[{now()}] Auto-detected Wan interface: L={auto_L}, D={auto_D} (overriding)."
             )
             args.L_wan, args.d_wan = auto_L, auto_D
 
+    # Bridge
     bridge = PerceiverBridge(
         d_llm=llm.config.hidden_size,
         d_wan=args.d_wan,
@@ -158,32 +197,53 @@ def main() -> None:
     optim = torch.optim.AdamW(bridge.parameters(), lr=args.lr, weight_decay=args.adamw)
     autocast_cm, scaler, amp_mode = build_autocast_and_scaler(args.amp)
 
+    # Data
     ds = CaptionsJSONL(args.captions, min_chars=1)
     dl = DataLoader(
         ds,
         batch_size=args.batch_size,
         shuffle=True,
-        num_workers=2,
+        num_workers=4,
+        pin_memory=True,
+        persistent_workers=True,
+        prefetch_factor=4,
         collate_fn=collate_text,
         drop_last=True,
     )
+    print(f"[{now()}] batches_per_epoch={len(dl)} (batch_size={args.batch_size})")
 
     global_step = 0
     anomaly_left = max(0, args.detect_anomaly_steps)
+    accum_step = 0
 
     for epoch in range(args.epochs):
         for batch_i, texts in enumerate(dl):
+            if args.max_steps and global_step >= args.max_steps:
+                ck_step = Path(args.save_dir) / f"bridge_step{global_step:06d}.pth"
+                torch.save({"bridge": bridge.state_dict(), "cfg": vars(args)}, ck_step)
+                print(
+                    f"[{now()}] Reached max_steps={args.max_steps}. Saved {ck_step} and exiting."
+                )
+                return
+
             use_anomaly = anomaly_left > 0
             anomaly_left -= 1 if use_anomaly else 0
 
             with detect_anomaly_if(use_anomaly):
-                llm_h, llm_mask = get_llm_hidden(llm, tok, texts, device=args.device)
+                # LLM features
+                llm_h, llm_mask = get_llm_hidden(
+                    llm,
+                    tok,
+                    texts,
+                    device=args.device,
+                    llm_max_length=args.llm_max_length,
+                )
 
                 with autocast_cm:
                     h_hat = bridge(llm_h.to(args.device), llm_mask.to(args.device))
+                    # teacher supervision
                     loss = torch.zeros([], device=args.device)
-
-                    stats_record: dict[str, object] = {
+                    stats_record = {
                         "step": global_step + 1,
                         "epoch": epoch,
                         "amp": amp_mode,
@@ -194,13 +254,12 @@ def main() -> None:
                             h_t, m_t = teacher(texts)
                         if h_hat.dtype != h_t.dtype:
                             h_hat = h_hat.to(h_t.dtype)
-
                         loss_mse = mse_loss(h_hat, h_t, mask=m_t)
                         loss_cos = cosine_loss(h_hat, h_t, mask=m_t)
                         loss_stats = match_stats_loss(h_hat, h_t, mask=m_t)
-                        loss = loss + (
-                            1.0 * loss_mse + 0.5 * loss_cos + 0.1 * loss_stats
-                        )
+                        # weights: slightly higher stats to tighten scale
+                        loss_total = 1.0 * loss_mse + 0.5 * loss_cos + 0.2 * loss_stats
+                        loss = loss + loss_total / args.grad_accum
 
                         stats_record["llm_h"] = tensor_stats(llm_h, llm_mask, "llm_h")
                         stats_record["h_hat"] = tensor_stats(h_hat, None, "bridge_out")
@@ -213,20 +272,28 @@ def main() -> None:
                     else:
                         mu = h_hat.mean(dim=(0, 1))
                         sigma = h_hat.std(dim=(0, 1))
-                        loss = loss + 0.1 * (
-                            torch.abs(mu).mean() + torch.abs(sigma - 1.0).mean()
+                        loss = (
+                            loss
+                            + (
+                                0.1
+                                * (torch.abs(mu).mean() + torch.abs(sigma - 1.0).mean())
+                            )
+                            / args.grad_accum
                         )
                         stats_record["llm_h"] = tensor_stats(llm_h, llm_mask, "llm_h")
                         stats_record["h_hat"] = tensor_stats(h_hat, None, "bridge_out")
-                        stats_record["losses"] = {"dist_only": float(loss.item())}
+                        stats_record["losses"] = {
+                            "dist_only": float(loss.item() * args.grad_accum)
+                        }
 
+                # NaN guard
                 bad = (
-                    not torch.isfinite(loss).item()
-                    or stats_record["h_hat"]["n_nan"] > 0
+                    (not torch.isfinite(loss).item())
+                    or (stats_record["h_hat"]["n_nan"] > 0)
                     or (teacher is not None and stats_record["h_t"]["n_nan"] > 0)
                 )
                 if bad:
-                    dump_path = dumps_dir / f"nan_step{global_step + 1:06d}.pt"
+                    dump_path = dumps_dir / f"nan_step{global_step+1:06d}.pt"
                     torch.save(
                         {
                             "texts": texts,
@@ -244,47 +311,85 @@ def main() -> None:
                         dump_path,
                     )
                     print(
-                        f"[{now()}] 🚨 Non-finite detected at step {global_step + 1}. Dumped to {dump_path}. Aborting."
+                        f"[{now()}] 🚨 Non-finite at step {global_step+1}. Dumped {dump_path}. Aborting."
                     )
                     return
 
-                optim.zero_grad(set_to_none=True)
+                # Backprop (with grad accumulation)
                 if scaler is not None:
                     scaler.scale(loss).backward()
-                    torch.nn.utils.clip_grad_norm_(bridge.parameters(), 1.0)
-                    scaler.step(optim)
-                    scaler.update()
                 else:
                     loss.backward()
+                accum_step += 1
+                do_step = (accum_step % args.grad_accum) == 0
+
+                if do_step:
                     torch.nn.utils.clip_grad_norm_(bridge.parameters(), 1.0)
-                    optim.step()
+                    if scaler is not None:
+                        scaler.step(optim)
+                        scaler.update()
+                    else:
+                        optim.step()
+                    optim.zero_grad(set_to_none=True)
+                    accum_step = 0
+                    global_step += 1
 
-                stats_record["grads"] = grad_norms(bridge, topk=8)
-                logger.log(stats_record)
+                    # log
+                    stats_record["grads"] = grad_norms(bridge, topk=8)
+                    # add sigma ratio to console visibility
+                    if "h_t" in stats_record:
+                        tstd = stats_record["h_t"]["std"]
+                        bstd = stats_record["h_hat"]["std"]
+                        stats_record["sigma_ratio"] = (
+                            (bstd / tstd) if tstd else float("nan")
+                        )
+                    logger.log(stats_record)
 
-                global_step += 1
-                if global_step % args.log_every == 0:
-                    print(
-                        f"[{now()}] ep{epoch} it{batch_i} step{global_step} "
-                        f"loss={float(loss.item()):.6f} "
-                        f"| h_hat μ={stats_record['h_hat']['mean']:.4f} σ={stats_record['h_hat']['std']:.4f} "
-                        f"| teacher μ={stats_record.get('h_t', {}).get('mean', '-')}"
-                    )
+                    if global_step % args.log_every == 0:
+                        comp = stats_record.get("losses", {})
+                        tstd = stats_record.get("h_t", {}).get("std", float("nan"))
+                        bstd = stats_record["h_hat"]["std"]
+                        ratio = (
+                            (bstd / tstd)
+                            if (isinstance(tstd, float) and tstd != 0)
+                            else float("nan")
+                        )
+                        print(
+                            f"[{now()}] ep{epoch} it{batch_i} step{global_step} "
+                            f"loss={float((sum(comp.values()) if comp else loss.item())):.6f} "
+                            f"| mse={comp.get('mse','-'):.6f} cos={comp.get('cos','-'):.6f} stats={comp.get('stats','-'):.6f} "
+                            f"| ĥ σ={bstd:.4f}  teacher σ={tstd:.4f}  σ_ratio={ratio:.3f}"
+                        )
 
-                if args.debug_dump_every and (global_step % args.debug_dump_every == 0):
-                    dump_path = dumps_dir / f"step{global_step:06d}.pt"
-                    torch.save(
-                        {
-                            "texts": texts,
-                            "llm_h": llm_h.cpu(),
-                            "h_hat": h_hat.detach().cpu(),
-                            "teacher_out": (
-                                h_t.detach().cpu() if teacher is not None else None
-                            ),
-                        },
-                        dump_path,
-                    )
+                    # periodic checkpoint
+                    if args.save_every_steps and (
+                        global_step % args.save_every_steps == 0
+                    ):
+                        ck = Path(args.save_dir) / f"bridge_step{global_step:06d}.pth"
+                        torch.save(
+                            {"bridge": bridge.state_dict(), "cfg": vars(args)}, ck
+                        )
+                        print(f"[{now()}] saved {ck}")
+                        if args.save_keep_last_k > 0:
+                            step_ckpts = sorted(
+                                Path(args.save_dir).glob("bridge_step*.pth")
+                            )
+                            for old in step_ckpts[: -args.save_keep_last_k]:
+                                try:
+                                    old.unlink()
+                                except Exception:
+                                    pass
 
+                    # on-demand checkpoint (kill -USR1 <pid>)
+                    if _save_now["flag"]:
+                        _save_now["flag"] = False
+                        ck = Path(args.save_dir) / f"bridge_step{global_step:06d}.pth"
+                        torch.save(
+                            {"bridge": bridge.state_dict(), "cfg": vars(args)}, ck
+                        )
+                        print(f"[{now()}] Saved on USR1 -> {ck}")
+
+        # end epoch save
         ckpt = {"bridge": bridge.state_dict(), "cfg": vars(args)}
         outp = Path(args.save_dir) / f"bridge_epoch{epoch:02d}.pth"
         torch.save(ckpt, outp)

--- a/bridge/train_bridge_from_cache.py
+++ b/bridge/train_bridge_from_cache.py
@@ -1,0 +1,256 @@
+import argparse
+import os
+import random
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from adapter import PerceiverBridge
+from utils import (
+    mse_loss,
+    cosine_loss,
+    match_stats_loss,
+    now,
+    JsonlLogger,
+    grad_norms,
+    tensor_stats,
+)
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+try:
+    torch.set_float32_matmul_precision("high")
+except Exception:
+    pass
+
+
+class CacheIndex(Dataset):
+    def __init__(self, cache_dir):
+        self.files = sorted(Path(cache_dir).glob("shard_*.pt"))
+        self.index = []  # (file_idx, local_idx)
+        self.meta = []
+        for fi, f in enumerate(self.files):
+            sh = torch.load(f, map_location="cpu")
+            n = sh["wan_h"].shape[0]
+            self.meta.append(
+                {
+                    "path": f,
+                    "n": n,
+                    "shape_llm": list(sh["llm_h"].shape),
+                    "shape_wan": list(sh["wan_h"].shape),
+                }
+            )
+            self.index.extend([(fi, j) for j in range(n)])
+        random.shuffle(self.index)
+
+    def __len__(self):
+        return len(self.index)
+
+    def __getitem__(self, i):
+        return self.index[i]
+
+
+def collate_fetch(batch, cache):
+    # batch: list of (file_idx, local_idx)
+    by_file = {}
+    for fi, li in batch:
+        by_file.setdefault(fi, []).append(li)
+    # load per-file once
+    X = []
+    for fi, lis in by_file.items():
+        sh = cache._loaded.get(fi)
+        if sh is None:
+            sh = torch.load(cache.files[fi], map_location="cpu")
+            cache._loaded[fi] = sh
+        for li in lis:
+            X.append(
+                (
+                    sh["llm_h"][li],
+                    sh["llm_mask"][li],
+                    sh["wan_h"][li],
+                    sh["wan_mask"][li],
+                )
+            )
+    # pad llm to max Lt in batch
+    Lt = max(x[0].shape[0] for x in X)
+    B = len(X)
+    d_llm = X[0][0].shape[-1]
+    llm_h = torch.zeros(B, Lt, d_llm, dtype=X[0][0].dtype)
+    llm_mask = torch.zeros(B, Lt, dtype=torch.bool)
+    wan_h = torch.stack([x[2] for x in X], dim=0).contiguous()
+    wan_mask = torch.stack([x[3] for x in X], dim=0).contiguous()
+    for i, (h, m, _, _) in enumerate(X):
+        li = h.shape[0]
+        llm_h[i, :li, :] = h
+        llm_mask[i, :li] = m
+    return llm_h, llm_mask, wan_h, wan_mask
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cache_dir", required=True)
+    ap.add_argument("--save_dir", required=True)
+    ap.add_argument("--batch_size", type=int, default=32)
+    ap.add_argument("--epochs", type=int, default=1)
+    ap.add_argument("--lr", type=float, default=1e-4)
+    ap.add_argument("--adamw", type=float, default=0.01)
+    ap.add_argument("--amp", choices=["bf16", "fp16", "off"], default="bf16")
+    ap.add_argument("--log_every", type=int, default=50)
+    ap.add_argument("--save_every_steps", type=int, default=500)
+    ap.add_argument("--save_keep_last_k", type=int, default=5)
+    ap.add_argument("--device", default="cuda")
+    args = ap.parse_args()
+
+    os.makedirs(args.save_dir, exist_ok=True)
+    logger = JsonlLogger(os.path.join(args.save_dir, "bridge_debug.jsonl"))
+
+    # build index and lazily load shards
+    cache = CacheIndex(args.cache_dir)
+    cache._loaded = {}
+    print(f"[{now()}] cached samples: {len(cache)} | shards: {len(cache.files)}")
+    print(f"[{now()}] first shard shapes: {cache.meta[0]}")
+
+    dl = DataLoader(
+        cache,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=4,
+        pin_memory=True,
+        persistent_workers=True,
+        collate_fn=lambda b: collate_fetch(b, cache),
+        drop_last=True,
+    )
+
+    # infer dims from first item
+    llm_h, llm_m, wan_h, wan_m = next(iter(dl))
+    d_llm = llm_h.shape[-1]
+    L_wan = wan_h.shape[1]
+    d_wan = wan_h.shape[2]
+    print(f"[{now()}] inferred dims: d_llm={d_llm}, L_wan={L_wan}, d_wan={d_wan}")
+
+    # bridge
+    bridge = PerceiverBridge(
+        d_llm=d_llm, d_wan=d_wan, L_wan=L_wan, d_mid=1024, n_heads=16, n_blocks=3
+    ).to(args.device)
+    optim = torch.optim.AdamW(bridge.parameters(), lr=args.lr, weight_decay=args.adamw)
+
+    # AMP
+    if args.amp == "fp16":
+        autocast_cm = torch.amp.autocast("cuda", dtype=torch.float16)
+        scaler = torch.amp.GradScaler("cuda")
+    elif args.amp == "bf16":
+        autocast_cm = torch.amp.autocast("cuda", dtype=torch.bfloat16)
+        scaler = None
+    else:
+
+        class NullCtx:
+            def __enter__(self):
+                return None
+
+            def __exit__(self, *a):
+                return False
+
+        autocast_cm, scaler = NullCtx(), None
+
+    global_step = 0
+    for ep in range(args.epochs):
+        for it, (llm_h, llm_m, wan_h, wan_m) in enumerate(dl):
+            llm_h, llm_m = llm_h.to(args.device, non_blocking=True), llm_m.to(
+                args.device, non_blocking=True
+            )
+            wan_h, wan_m = wan_h.to(args.device, non_blocking=True), wan_m.to(
+                args.device, non_blocking=True
+            )
+
+            with autocast_cm:
+                h_hat = bridge(llm_h, llm_m)
+                # same losses as live trainer
+                loss_mse = mse_loss(h_hat, wan_h, mask=wan_m)
+                loss_cos = cosine_loss(h_hat, wan_h, mask=wan_m)
+                loss_stats = match_stats_loss(h_hat, wan_h, mask=wan_m)
+                loss = 1.0 * loss_mse + 0.5 * loss_cos + 0.2 * loss_stats
+
+            if scaler is not None:
+                scaler.scale(loss).backward()
+                torch.nn.utils.clip_grad_norm_(bridge.parameters(), 1.0)
+                scaler.step(optim)
+                scaler.update()
+            else:
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_(bridge.parameters(), 1.0)
+                optim.step()
+            optim.zero_grad(set_to_none=True)
+
+            global_step += 1
+            if global_step % args.log_every == 0:
+                bstats = tensor_stats(h_hat, wan_m, "bridge")
+                tstats = tensor_stats(wan_h, wan_m, "teacher")
+                ratio = (
+                    (bstats["std"] / tstats["std"]) if tstats["std"] else float("nan")
+                )
+                logger.log(
+                    {
+                        "step": global_step,
+                        "epoch": ep,
+                        "losses": {
+                            "mse": float(loss_mse.item()),
+                            "cos": float(loss_cos.item()),
+                            "stats": float(loss_stats.item()),
+                        },
+                        "bridge": bstats,
+                        "teacher": tstats,
+                        "sigma_ratio": ratio,
+                        "grads": grad_norms(bridge, topk=8),
+                    }
+                )
+                print(
+                    f"[{now()}] ep{ep} it{it} step{global_step} loss={float(loss.item()):.6f} σ_ratio={ratio:.3f}"
+                )
+
+            if args.save_every_steps and (global_step % args.save_every_steps == 0):
+                ck = Path(args.save_dir) / f"bridge_step{global_step:06d}.pth"
+                torch.save(
+                    {
+                        "bridge": bridge.state_dict(),
+                        "cfg": {
+                            "L_wan": L_wan,
+                            "d_wan": d_wan,
+                            "d_llm": d_llm,
+                            "d_mid": 1024,
+                            "n_blocks": 3,
+                            "heads_mid": 16,
+                        },
+                    },
+                    ck,
+                )
+                print(f"[{now()}] saved {ck}")
+                if args.save_keep_last_k > 0:
+                    step_ckpts = sorted(Path(args.save_dir).glob("bridge_step*.pth"))
+                    for old in step_ckpts[: -args.save_keep_last_k]:
+                        try:
+                            old.unlink()
+                        except Exception:
+                            pass
+
+        # epoch end
+        ck = Path(args.save_dir) / f"bridge_epoch{ep:02d}.pth"
+        torch.save(
+            {
+                "bridge": bridge.state_dict(),
+                "cfg": {
+                    "L_wan": L_wan,
+                    "d_wan": d_wan,
+                    "d_llm": d_llm,
+                    "d_mid": 1024,
+                    "n_blocks": 3,
+                    "heads_mid": 16,
+                },
+            },
+            ck,
+        )
+        print(f"[{now()}] saved {ck}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- enhance live bridge trainer with AMP/TF32, grad accumulation, and step-based checkpointing
- add precache_features.py to cache LLM and WAN tensors
- add train_bridge_from_cache.py for fast bridge training from cached shards

## Testing
- `ruff check bridge/train_bridge.py bridge/precache_features.py bridge/train_bridge_from_cache.py`
- `pytest` *(fails: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/workspace/models/MythoMax-L2-13B')*

------
https://chatgpt.com/codex/tasks/task_e_68ad482942cc83239cab3c4bc344ceae