### PR TITLE
Fix variable shadowing in precache feature script

### DIFF
--- a/bridge/precache_features.py
+++ b/bridge/precache_features.py
@@ -1,11 +1,12 @@
 import argparse
 import json
+import gc
 from pathlib import Path
 
 import torch
-from transformers import AutoModel, AutoTokenizer
+from transformers import AutoTokenizer, AutoModel
 
-# Prefer TF32 kernels on A100 (throughput boost)
+# Throughput knobs on A100
 torch.backends.cuda.matmul.allow_tf32 = True
 torch.backends.cudnn.allow_tf32 = True
 try:
@@ -26,17 +27,17 @@ except Exception:
 
 def iter_captions(jsonl_path, start=0, count=0):
     with open(jsonl_path, "r", encoding="utf-8") as f:
-        i0 = 0
+        i = 0
         for line in f:
-            if i0 < start:
-                i0 += 1
+            if i < start:
+                i += 1
                 continue
             j = json.loads(line)
             cap = (j.get("caption") or "").strip()
             if cap:
-                yield i0, cap
-            i0 += 1
-            if count and (i0 - start) >= count:
+                yield i, cap
+            i += 1
+            if count and (i - start) >= count:
                 break
 
 
@@ -46,33 +47,30 @@ def main():
     ap.add_argument("--llm_dir", required=True)
     ap.add_argument("--out_dir", required=True)
     ap.add_argument("--shard_size", type=int, default=2000)
-    ap.add_argument(
-        "--microbatch", type=int, default=64, help="per-GPU microbatch during caching"
-    )
+    ap.add_argument("--microbatch", type=int, default=64, help="per-GPU microbatch")
     ap.add_argument("--llm_max_length", type=int, default=512)
     ap.add_argument("--start", type=int, default=0)
     ap.add_argument("--count", type=int, default=0, help="0=all")
     ap.add_argument("--device", default="cuda")
     args = ap.parse_args()
 
-    out = Path(args.out_dir)
-    out.mkdir(parents=True, exist_ok=True)
+    # Use distinct names so we never shadow them
+    out_dir_path = Path(args.out_dir)
+    out_dir_path.mkdir(parents=True, exist_ok=True)
 
-    print("[precache] loading LLM (base decoder) …")
+    print("[precache] loading LLM (base decoder)…")
     tok = AutoTokenizer.from_pretrained(args.llm_dir, use_fast=True)
-    # Use AutoModel (LlamaModel), not ForCausalLM, to avoid logits & extra buffers
-    llm = AutoModel.from_pretrained(
+    # Use AutoModel (decoder base) so we can read last_hidden_state directly
+    llm_model = AutoModel.from_pretrained(
         args.llm_dir, torch_dtype=torch.bfloat16, device_map="auto"
     )
-    llm.eval().requires_grad_(False)
+    llm_model.eval().requires_grad_(False)
 
-    print("[precache] loading Wan teacher …")
-    # Your Wan teacher wrapper (GPU). Adjust import path if needed.
+    print("[precache] loading Wan teacher…")
     from teachers.wan_text_teacher_from_wan import WanTextTeacher
 
     teacher = WanTextTeacher(L_wan=512, d_wan=None, device=args.device).eval()
 
-    # Buffers for one shard
     buf_idx, buf_caps = [], []
     shard_id, total = 0, 0
 
@@ -84,87 +82,60 @@ def main():
             padding=True,
             truncation=True,
             max_length=args.llm_max_length,
-        ).to(llm.device)
-        # AutoModel returns BaseModelOutputWithPast; use last_hidden_state directly
+        ).to(llm_model.device)
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = llm(
-                **enc,
-                output_hidden_states=False,
-                use_cache=False,
-                return_dict=True,
+            llm_out = llm_model(
+                **enc, output_hidden_states=False, use_cache=False, return_dict=True
             )
-        h = out.last_hidden_state.to(torch.bfloat16)  # [b, Lt, d_llm]
+        h = llm_out.last_hidden_state.to(torch.bfloat16)  # [b, Lt, d_llm]
         m = enc["attention_mask"].bool()
         return h, m
 
     @torch.inference_mode()
     def encode_teacher(batch_caps):
-        # Wan teacher already returns bf16 on CUDA
-        return teacher(batch_caps)
+        return teacher(batch_caps)  # [b, 512, 4096], [b, 512]
 
     def flush_shard():
         nonlocal shard_id, total, buf_idx, buf_caps
         if not buf_caps:
             return
         print(
-            f"[precache] shard {shard_id:05d} — computing {len(buf_caps)} samples "
-            f"(microbatch={args.microbatch})"
+            f"[precache] shard {shard_id:05d} — computing {len(buf_caps)} samples (microbatch={args.microbatch})"
         )
 
-        # Make these per-sample lists (NOT per-microbatch tensors)
+        # Per-sample lists (NOT per-microbatch tensors)
         llm_h_list, llm_m_list = [], []
         wan_h_list, wan_m_list = [], []
 
-        # process in micro-batches to keep peak VRAM low
         for i in range(0, len(buf_caps), args.microbatch):
             caps_mb = buf_caps[i : i + args.microbatch]
 
-            # ---- LLM forward (bf16) ----
-            enc = tok(
-                caps_mb,
-                return_tensors="pt",
-                padding=True,
-                truncation=True,
-                max_length=args.llm_max_length,
-            ).to(llm.device)
-            with torch.inference_mode(), torch.amp.autocast(
-                "cuda", dtype=torch.bfloat16
-            ):
-                out = llm(
-                    **enc,
-                    output_hidden_states=False,
-                    use_cache=False,
-                    return_dict=True,
-                )
-            h_llm = out.last_hidden_state.to(torch.bfloat16)  # [B_mb, Lt_mb, d_llm]
-            m_llm = enc["attention_mask"].bool()  # [B_mb, Lt_mb]
-
-            # split to per-sample tensors on CPU
+            # ---- LLM (bf16) ----
+            h_llm, m_llm = encode_llm(caps_mb)  # [Bmb, Lt, d_llm], [Bmb, Lt]
             h_llm_cpu = h_llm.cpu()
             m_llm_cpu = m_llm.cpu()
             for b in range(h_llm_cpu.shape[0]):
                 llm_h_list.append(h_llm_cpu[b])  # [Lt_i, d_llm]
                 llm_m_list.append(m_llm_cpu[b])  # [Lt_i]
 
-            # ---- Teacher forward (bf16) ----
-            with torch.inference_mode():
-                h_wan, m_wan = teacher(caps_mb)  # [B_mb, 512, 4096], [B_mb, 512]
+            # ---- Teacher (bf16) ----
+            h_wan, m_wan = encode_teacher(caps_mb)  # [Bmb, 512, 4096], [Bmb, 512]
             wan_h_list.append(h_wan.to(torch.bfloat16).cpu())
             wan_m_list.append(m_wan.cpu())
 
-            # free GPU scratch
-            del h_llm, m_llm, h_wan, m_wan
+            # Free scratch
+            del h_llm, m_llm, h_wan, m_wan, h_llm_cpu, m_llm_cpu
             torch.cuda.empty_cache()
+            gc.collect()
 
-        # pad per-sample lists to a common Lt_shard
+        # Pad per-sample LLM sequences to shard max Lt
         llm_h = torch.nn.utils.rnn.pad_sequence(
             llm_h_list, batch_first=True
         )  # [N, Lt_shard, d_llm]
         llm_m = torch.nn.utils.rnn.pad_sequence(
             llm_m_list, batch_first=True
         )  # [N, Lt_shard]
-
-        # concat teacher lists (already fixed length)
+        # Concatenate teacher (fixed length)
         wan_h = torch.cat(wan_h_list, dim=0).contiguous()  # [N, 512, 4096]
         wan_m = torch.cat(wan_m_list, dim=0).contiguous()  # [N, 512]
 
@@ -176,7 +147,7 @@ def main():
             "wan_h": wan_h,  # bf16, CPU
             "wan_mask": wan_m,  # bool, CPU
         }
-        path = out / f"shard_{shard_id:05d}.pt"
+        path = out_dir_path / f"shard_{shard_id:05d}.pt"
         torch.save(shard, path)
         total += len(buf_caps)
         print(f"[precache] wrote {path}  (n={len(buf_caps)}, total={total})")
@@ -184,7 +155,7 @@ def main():
         shard_id += 1
         buf_idx, buf_caps = [], []
 
-    # fill shards
+    # Fill shards
     for i, cap in iter_captions(args.captions, start=args.start, count=args.count):
         buf_idx.append(i)
         buf_caps.append(cap)
@@ -195,4 +166,7 @@ def main():
 
 
 if __name__ == "__main__":
+    # Helpful alloc flags — set once in your shell if you haven’t:
+    #   export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:256
+    #   export TOKENIZERS_PARALLELISM=true
     main()


### PR DESCRIPTION
## Summary
- avoid collision between output directory path and LLM output by renaming to `out_dir_path`
- keep micro-batched encoding and per-sample padding for LLM and teacher features

## Testing
- `ruff check bridge/precache_features.py`
- `black bridge/precache_features.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68ad5b409da08323ad4f400d62fe4d72