### PR TITLE
Add KV LoRA injector and distillation trainer

### DIFF
--- a/kv_lora_inject.py
+++ b/kv_lora_inject.py
@@ -1,0 +1,142 @@
+# kv_lora_inject.py
+# Minimal LoRA for Wan cross-attention K/V projections (single adapter file).
+# Works without PEFT; produces a PEFT-compatible state dict for adapter_model.safetensors.
+
+from __future__ import annotations
+from typing import Dict, Iterable, List, Tuple
+
+import torch
+import torch.nn as nn
+from safetensors.torch import save_file as safetensors_save
+import math
+
+
+# ---- LoRA modules ----
+
+
+class LoRALinear(nn.Module):
+    def __init__(
+        self, base: nn.Linear, rank: int = 8, alpha: float = 32.0, dropout: float = 0.0
+    ):
+        super().__init__()
+        self.in_features = base.in_features
+        self.out_features = base.out_features
+        self.rank = rank
+        self.alpha = alpha
+        self.scaling = alpha / rank if rank > 0 else 0.0
+        self.dropout = nn.Dropout(dropout) if dropout and dropout > 0 else nn.Identity()
+
+        # Keep a reference to the base linear
+        self.base = base
+        # LoRA weights (A: in->r, B: r->out). Zero-init so it's identity at start.
+        if rank > 0:
+            self.lora_A = nn.Linear(self.in_features, rank, bias=False)
+            self.lora_B = nn.Linear(rank, self.out_features, bias=False)
+            nn.init.kaiming_uniform_(self.lora_A.weight, a=math.sqrt(5))
+            nn.init.zeros_(self.lora_B.weight)  # ensures initial delta ~ 0
+        else:
+            # Rank 0 -> disabled lora (for completeness)
+            self.lora_A = None
+            self.lora_B = None
+
+        # Switch to enable/disable LoRA at forward
+        self.enabled = True
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        y = self.base(x)
+        if self.lora_A is None or not self.enabled:
+            return y
+        return y + self.dropout(self.lora_B(self.lora_A(x))) * self.scaling
+
+    @property
+    def weight(self):
+        # Proxy to match nn.Linear API (read-only)
+        return self.base.weight
+
+    @property
+    def bias(self):
+        return self.base.bias
+
+    def trainable_parameters(self) -> Iterable[nn.Parameter]:
+        if self.lora_A is not None:
+            yield from self.lora_A.parameters()
+            yield from self.lora_B.parameters()
+
+
+def _replace_linear_with_lora(
+    module: nn.Module, attr: str, rank: int, alpha: float, dropout: float
+) -> LoRALinear:
+    base = getattr(module, attr)
+    assert isinstance(
+        base, nn.Linear
+    ), f"Expected nn.Linear at {attr}, got {type(base)}"
+    lora = LoRALinear(base, rank=rank, alpha=alpha, dropout=dropout)
+    setattr(module, attr, lora)
+    return lora
+
+
+def inject_lora_kv(
+    model: nn.Module,
+    blocks_attr: str = "blocks",
+    cross_attr: str = "cross_attn",
+    targets: Tuple[str, ...] = ("k", "v"),
+    rank: int = 8,
+    alpha: float = 32.0,
+    dropout: float = 0.0,
+    blocks_range: Tuple[int, int] | None = None,
+) -> Dict[str, LoRALinear]:
+    """
+    Replace cross-attn .k and .v linears with LoRALinear in all WanAttentionBlocks.
+
+    Returns: dict mapping module path -> LoRALinear
+    """
+    loras: Dict[str, LoRALinear] = {}
+    blocks = getattr(model, blocks_attr)
+    n = len(blocks)
+    start, end = (0, n - 1) if blocks_range is None else blocks_range
+    for i in range(start, end + 1):
+        blk = blocks[i]
+        ca = getattr(blk, cross_attr, None)
+        if ca is None:
+            continue
+        for tgt in targets:
+            if hasattr(ca, tgt):
+                path = f"{blocks_attr}.{i}.{cross_attr}.{tgt}"
+                loras[path] = _replace_linear_with_lora(ca, tgt, rank, alpha, dropout)
+    return loras
+
+
+def set_lora_enabled(model: nn.Module, enabled: bool = True):
+    for m in model.modules():
+        if isinstance(m, LoRALinear):
+            m.enabled = enabled
+
+
+def lora_parameters(model: nn.Module) -> List[nn.Parameter]:
+    params: List[nn.Parameter] = []
+    for m in model.modules():
+        if isinstance(m, LoRALinear):
+            params += list(m.trainable_parameters())
+    return params
+
+
+# ---- Save / load in PEFT-ish format ----
+
+
+def export_peft_adapter(
+    model: nn.Module, save_path: str, prefix: str = "diffusion_model."
+) -> None:
+    """
+    Export only LoRA tensors in a PEFT-compatible key format so existing loaders can consume it:
+      diffusion_model.blocks.{i}.cross_attn.{k,v}.lora_A.weight
+      diffusion_model.blocks.{i}.cross_attn.{k,v}.lora_B.weight
+    """
+    state: Dict[str, torch.Tensor] = {}
+    for name, module in model.named_modules():
+        if isinstance(module, LoRALinear):
+            # name ends with "...blocks.{i}.cross_attn.k"
+            key_A = f"{prefix}{name}.lora_A.weight"
+            key_B = f"{prefix}{name}.lora_B.weight"
+            state[key_A] = module.lora_A.weight.detach().cpu()
+            state[key_B] = module.lora_B.weight.detach().cpu()
+    safetensors_save(state, save_path, metadata={"format": "pt"})

--- a/train_kv_lora_distill.py
+++ b/train_kv_lora_distill.py
@@ -1,0 +1,250 @@
+"""Train a KV-only LoRA adapter by distilling Wan cross-attention projections.
+
+This script loads a Wan diffusion backbone, injects LoRA modules into all
+cross-attention K and V projections and optimizes those adapters so that the
+keys/values produced from a bridge encoder match those from the original
+UMT5 encoder.
+
+It intentionally keeps the diffusion transformer frozen and only trains the
+LoRA parameters, allowing the resulting weights to be exported in a
+PEFT-compatible format.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import List, Tuple
+
+import torch
+from torch.optim import AdamW
+from torch.utils.data import DataLoader, Dataset
+from safetensors.torch import load_file
+
+from kv_lora_inject import (
+    export_peft_adapter,
+    inject_lora_kv,
+    lora_parameters,
+    set_lora_enabled,
+)
+
+# Wan imports live under the inference package.
+import sys
+
+# The Wan2.2 inference package uses a directory name with a dot. To make it
+# importable as a Python package we append it to ``sys.path`` and then import
+# from the ``wan`` submodule.
+WAN22_DIR = Path(__file__).resolve().parent / "inference" / "Wan2.2"
+sys.path.append(str(WAN22_DIR))
+from wan.modules.model import WanModel  # type: ignore  # noqa: E402
+from wan.modules.t5 import T5EncoderModel  # type: ignore  # noqa: E402
+from wan.modules.t5_bridge import BridgeEncoderModel  # type: ignore  # noqa: E402
+
+
+# -----------------------------------------------------------------------------
+# Data helpers
+# -----------------------------------------------------------------------------
+
+
+class PromptDataset(Dataset):
+    """Simple dataset reading prompts from a text file."""
+
+    def __init__(self, path: str):
+        with open(path, "r", encoding="utf-8") as f:
+            self.prompts = [line.strip() for line in f.readlines() if line.strip()]
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.prompts)
+
+    def __getitem__(self, idx: int) -> str:  # pragma: no cover - trivial
+        return self.prompts[idx]
+
+
+# -----------------------------------------------------------------------------
+# Encoding utilities
+# -----------------------------------------------------------------------------
+
+
+def pad_stack(
+    tokens: List[torch.Tensor], max_len: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Pad variable length token sequences to `max_len`.
+
+    Returns tuple (padded, mask) with shapes [B, max_len, C] and [B, max_len, 1].
+    """
+
+    b = len(tokens)
+    d = tokens[0].shape[-1]
+    padded = torch.zeros(b, max_len, d, device=tokens[0].device, dtype=tokens[0].dtype)
+    mask = torch.zeros(b, max_len, 1, device=tokens[0].device, dtype=torch.float32)
+    for i, t in enumerate(tokens):
+        length = min(t.shape[0], max_len)
+        padded[i, :length] = t[:length]
+        mask[i, :length, 0] = 1.0
+    return padded, mask
+
+
+def encode_teacher(
+    prompts: List[str], encoder: T5EncoderModel, device: torch.device, max_len: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    tokens = encoder(prompts, device)
+    return pad_stack(tokens, max_len)
+
+
+def encode_bridge(
+    prompts: List[str], encoder: BridgeEncoderModel, device: torch.device, max_len: int
+) -> torch.Tensor:
+    tokens = encoder(prompts, device)
+    # Bridge already returns fixed length tensors but pad just in case
+    padded, _ = pad_stack(tokens, max_len)
+    return padded
+
+
+# -----------------------------------------------------------------------------
+# Training helpers
+# -----------------------------------------------------------------------------
+
+
+def compute_kv(
+    model: WanModel, context: torch.Tensor, use_norm: bool
+) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+    k_list: List[torch.Tensor] = []
+    v_list: List[torch.Tensor] = []
+    for blk in model.blocks:
+        ca = blk.cross_attn
+        k = ca.k(context)
+        v = ca.v(context)
+        if use_norm and hasattr(ca, "norm_k"):
+            k = ca.norm_k(k)
+        k_list.append(k)
+        v_list.append(v)
+    return k_list, v_list
+
+
+# -----------------------------------------------------------------------------
+# Main training routine
+# -----------------------------------------------------------------------------
+
+
+def train(args: argparse.Namespace) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # --- load Wan model ---------------------------------------------------
+    with open(args.transformer_config, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
+    model = WanModel(**cfg).to(device)
+
+    # load only required weights
+    sd = load_file(args.transformer_weights)
+    filtered = {
+        k: v
+        for k, v in sd.items()
+        if k.startswith("text_embedding") or ".cross_attn." in k
+    }
+    model.load_state_dict(filtered, strict=False)
+    model.requires_grad_(False)
+
+    # inject LoRA modules
+    inject_lora_kv(model, rank=args.rank, alpha=args.alpha)
+
+    # --- encoders ---------------------------------------------------------
+    teacher_enc = T5EncoderModel(
+        text_len=model.config.text_len,
+        checkpoint_path=args.t5_checkpoint,
+        tokenizer_path=args.t5_tokenizer,
+        device=device,
+        dtype=torch.bfloat16 if args.bf16 else torch.float32,
+    )
+
+    # bridge env variables
+    os.environ["WAN_BRIDGE_CKPT"] = args.bridge_ckpt
+    os.environ["WAN_BRIDGE_LLM_DIR"] = args.llm_dir
+    os.environ["WAN_BRIDGE_GLOBAL_SCALE"] = str(args.global_scale)
+    bridge_enc = BridgeEncoderModel(
+        text_len=model.config.text_len,
+        device=device,
+        dtype=torch.bfloat16 if args.bf16 else torch.float32,
+    )
+
+    dataset = PromptDataset(args.prompts_file)
+    loader = DataLoader(
+        dataset, batch_size=args.batch_size, shuffle=True, drop_last=False
+    )
+
+    params = lora_parameters(model)
+    optim = AdamW(params, lr=args.lr, weight_decay=0.0)
+
+    for epoch in range(args.epochs):
+        for batch_prompts in loader:
+            if isinstance(batch_prompts, tuple):
+                batch_prompts = list(batch_prompts)
+            # teacher pass (LoRA disabled)
+            set_lora_enabled(model, False)
+            with torch.no_grad():
+                teacher_tokens, mask = encode_teacher(
+                    batch_prompts, teacher_enc, device, model.config.text_len
+                )
+                teacher_context = model.text_embedding(teacher_tokens.float())
+                k_t, v_t = compute_kv(model, teacher_context, args.use_normed_targets)
+
+            # student pass (LoRA enabled)
+            set_lora_enabled(model, True)
+            bridge_tokens = encode_bridge(
+                batch_prompts, bridge_enc, device, model.config.text_len
+            )
+            bridge_context = model.text_embedding(bridge_tokens.float())
+            k_s, v_s = compute_kv(model, bridge_context, args.use_normed_targets)
+
+            # loss
+            loss = torch.tensor(0.0, device=device)
+            for kt, ks, vt, vs in zip(k_t, k_s, v_t, v_s):
+                mse_k = ((ks - kt) ** 2) * mask
+                mse_v = ((vs - vt) ** 2) * mask
+                denom = mask.sum().clamp_min(1.0)
+                loss = loss + mse_k.sum() / denom + mse_v.sum() / denom
+
+            optim.zero_grad()
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(params, 1.0)
+            optim.step()
+
+        print(f"Epoch {epoch+1}/{args.epochs} - loss {loss.item():.4f}")
+
+    # save adapter
+    Path(args.out_dir).mkdir(parents=True, exist_ok=True)
+    out_path = os.path.join(args.out_dir, "adapter_model.safetensors")
+    export_peft_adapter(model, out_path)
+    print(f"Saved adapter to {out_path}")
+
+
+# -----------------------------------------------------------------------------
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="KV LoRA distillation trainer")
+    p.add_argument("--transformer_config", type=str, required=True)
+    p.add_argument("--transformer_weights", type=str, required=True)
+    p.add_argument("--t5_checkpoint", type=str, required=True)
+    p.add_argument("--t5_tokenizer", type=str, required=True)
+    p.add_argument("--prompts_file", type=str, required=True)
+    p.add_argument("--out_dir", type=str, required=True)
+    p.add_argument("--bridge_ckpt", type=str, required=True)
+    p.add_argument("--llm_dir", type=str, required=True)
+    p.add_argument("--global_scale", type=float, default=1.0)
+    p.add_argument("--rank", type=int, default=8)
+    p.add_argument("--alpha", type=float, default=32.0)
+    p.add_argument("--lr", type=float, default=1e-4)
+    p.add_argument("--epochs", type=int, default=1)
+    p.add_argument("--batch_size", type=int, default=8)
+    p.add_argument("--use_normed_targets", action="store_true")
+    p.add_argument(
+        "--bf16", action="store_true", help="Use bfloat16 precision for encoders"
+    )
+    return p
+
+
+if __name__ == "__main__":
+    parser = build_argparser()
+    train(parser.parse_args())


### PR DESCRIPTION
## Summary
- add `kv_lora_inject.py` providing minimal LoRA module for cross-attention K/V projections and PEFT-style export
- add `train_kv_lora_distill.py` script to distill K/V outputs from bridge encoder to teacher UMT5

## Testing
- `black kv_lora_inject.py train_kv_lora_distill.py`
- `ruff check kv_lora_inject.py train_kv_lora_distill.py`
- `python -m py_compile kv_lora_inject.py train_kv_lora_distill.py`
- `pytest -q` *(fails: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/workspace/models/MythoMax-L2-13B')*

------
https://chatgpt.com/codex/tasks/task_e_68af6aa55c7c8323a8c79eef0baa8771