### PR TITLE
feat: enable kv-lora runtime loading and sampling

### DIFF
--- a/inference/Wan2.2/generate.py
+++ b/inference/Wan2.2/generate.py
@@ -5,9 +5,6 @@ import os
 import sys
 import warnings
 from datetime import datetime
-
-warnings.filterwarnings('ignore')
-
 import random
 
 import torch
@@ -15,33 +12,30 @@ import torch.distributed as dist
 from PIL import Image
 
 import wan
+from wan.modules.model import WanModel
 from wan.configs import MAX_AREA_CONFIGS, SIZE_CONFIGS, SUPPORTED_SIZES, WAN_CONFIGS
 from wan.distributed.util import init_distributed_group
 from wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander
 from wan.utils.utils import merge_video_audio, save_video, str2bool
+from kv_lora_inject import load_peft_adapter
+
+warnings.filterwarnings("ignore")
 
 EXAMPLE_PROMPT = {
     "t2v-A14B": {
-        "prompt":
-            "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage.",
+        "prompt": "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage.",
     },
     "i2v-A14B": {
-        "prompt":
-            "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside.",
-        "image":
-            "examples/i2v_input.JPG",
+        "prompt": "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside.",
+        "image": "examples/i2v_input.JPG",
     },
     "ti2v-5B": {
-        "prompt":
-            "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage.",
+        "prompt": "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage.",
     },
     "s2v-14B": {
-        "prompt":
-            "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside.",
-        "image":
-            "examples/i2v_input.JPG",
-        "audio":
-            "examples/talk.wav",
+        "prompt": "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside.",
+        "image": "examples/i2v_input.JPG",
+        "audio": "examples/talk.wav",
     },
 }
 
@@ -76,13 +70,14 @@ def _validate_args(args):
     if args.frame_num is None:
         args.frame_num = cfg.frame_num
 
-    args.base_seed = args.base_seed if args.base_seed >= 0 else random.randint(
-        0, sys.maxsize)
+    args.base_seed = (
+        args.base_seed if args.base_seed >= 0 else random.randint(0, sys.maxsize)
+    )
     # Size check
-    if not 's2v' in args.task:
-        assert args.size in SUPPORTED_SIZES[
-            args.
-            task], f"Unsupport size {args.size} for task {args.task}, supported sizes are: {', '.join(SUPPORTED_SIZES[args.task])}"
+    if "s2v" not in args.task:
+        assert (
+            args.size in SUPPORTED_SIZES[args.task]
+        ), f"Unsupport size {args.size} for task {args.task}, supported sizes are: {', '.join(SUPPORTED_SIZES[args.task])}"
 
 
 def _parse_args():
@@ -94,145 +89,179 @@ def _parse_args():
         type=str,
         default="t2v-A14B",
         choices=list(WAN_CONFIGS.keys()),
-        help="The task to run.")
+        help="The task to run.",
+    )
     parser.add_argument(
         "--size",
         type=str,
         default="1280*720",
         choices=list(SIZE_CONFIGS.keys()),
-        help="The area (width*height) of the generated video. For the I2V task, the aspect ratio of the output video will follow that of the input image."
+        help="The area (width*height) of the generated video. For the I2V task, the aspect ratio of the output video will follow that of the input image.",
     )
     parser.add_argument(
         "--frame_num",
         type=int,
         default=None,
-        help="How many frames of video are generated. The number should be 4n+1"
+        help="How many frames of video are generated. The number should be 4n+1",
     )
     parser.add_argument(
         "--ckpt_dir",
         type=str,
         default=None,
-        help="The path to the checkpoint directory.")
+        help="The path to the checkpoint directory.",
+    )
     parser.add_argument(
         "--offload_model",
         type=str2bool,
         default=None,
-        help="Whether to offload the model to CPU after each model forward, reducing GPU memory usage."
+        help="Whether to offload the model to CPU after each model forward, reducing GPU memory usage.",
     )
     parser.add_argument(
         "--ulysses_size",
         type=int,
         default=1,
-        help="The size of the ulysses parallelism in DiT.")
+        help="The size of the ulysses parallelism in DiT.",
+    )
     parser.add_argument(
         "--t5_fsdp",
         action="store_true",
         default=False,
-        help="Whether to use FSDP for T5.")
+        help="Whether to use FSDP for T5.",
+    )
     parser.add_argument(
         "--t5_cpu",
         action="store_true",
         default=False,
-        help="Whether to place T5 model on CPU.")
+        help="Whether to place T5 model on CPU.",
+    )
     parser.add_argument(
         "--dit_fsdp",
         action="store_true",
         default=False,
-        help="Whether to use FSDP for DiT.")
+        help="Whether to use FSDP for DiT.",
+    )
     parser.add_argument(
         "--save_file",
         type=str,
         default=None,
-        help="The file to save the generated video to.")
+        help="The file to save the generated video to.",
+    )
     parser.add_argument(
         "--prompt",
         type=str,
         default=None,
-        help="The prompt to generate the video from.")
+        help="The prompt to generate the video from.",
+    )
     parser.add_argument(
         "--use_prompt_extend",
         action="store_true",
         default=False,
-        help="Whether to use prompt extend.")
+        help="Whether to use prompt extend.",
+    )
     parser.add_argument(
         "--prompt_extend_method",
         type=str,
         default="local_qwen",
         choices=["dashscope", "local_qwen"],
-        help="The prompt extend method to use.")
+        help="The prompt extend method to use.",
+    )
     parser.add_argument(
         "--prompt_extend_model",
         type=str,
         default=None,
-        help="The prompt extend model to use.")
+        help="The prompt extend model to use.",
+    )
     parser.add_argument(
         "--prompt_extend_target_lang",
         type=str,
         default="zh",
         choices=["zh", "en"],
-        help="The target language of prompt extend.")
+        help="The target language of prompt extend.",
+    )
     parser.add_argument(
         "--base_seed",
         type=int,
         default=-1,
-        help="The seed to use for generating the video.")
+        help="The seed to use for generating the video.",
+    )
     parser.add_argument(
-        "--image",
-        type=str,
-        default=None,
-        help="The image to generate the video from.")
+        "--image", type=str, default=None, help="The image to generate the video from."
+    )
     parser.add_argument(
         "--sample_solver",
         type=str,
-        default='unipc',
-        choices=['unipc', 'dpm++'],
-        help="The solver used to sample.")
+        default="unipc",
+        choices=["unipc", "dpm++"],
+        help="The solver used to sample.",
+    )
     parser.add_argument(
-        "--sample_steps", type=int, default=None, help="The sampling steps.")
+        "--sample_steps", type=int, default=None, help="The sampling steps."
+    )
     parser.add_argument(
         "--sample_shift",
         type=float,
         default=None,
-        help="Sampling shift factor for flow matching schedulers.")
+        help="Sampling shift factor for flow matching schedulers.",
+    )
     parser.add_argument(
         "--sample_guide_scale",
         type=float,
         default=None,
-        help="Classifier free guidance scale.")
+        help="Classifier free guidance scale.",
+    )
     parser.add_argument(
         "--convert_model_dtype",
         action="store_true",
         default=False,
-        help="Whether to convert model paramerters dtype.")
+        help="Whether to convert model paramerters dtype.",
+    )
+    # KV-LoRA (KV-only cross-attn) adapter support
+    parser.add_argument(
+        "--kv_lora_adapter",
+        type=str,
+        default=None,
+        help="Path to a KV-LoRA adapter .safetensors (KV-only cross-attn).",
+    )
+    parser.add_argument(
+        "--kv_lora_prefix",
+        type=str,
+        default="diffusion_model.",
+        help="Key prefix inside the adapter file (e.g., diffusion_model. or transformer.).",
+    )
+    parser.add_argument(
+        "--kv_lora_alpha",
+        type=float,
+        default=32.0,
+        help="LoRA alpha used during training; controls scaling at runtime.",
+    )
 
     # following args only works for s2v
     parser.add_argument(
         "--num_clip",
         type=int,
         default=None,
-        help="Number of video clips to generate, the whole video will not exceed the length of audio."
+        help="Number of video clips to generate, the whole video will not exceed the length of audio.",
     )
     parser.add_argument(
-        "--audio",
-        type=str,
-        default=None,
-        help="Path to the audio file, e.g. wav, mp3")
+        "--audio", type=str, default=None, help="Path to the audio file, e.g. wav, mp3"
+    )
     parser.add_argument(
         "--pose_video",
         type=str,
         default=None,
-        help="Provide Dw-pose sequence to do Pose Driven")
+        help="Provide Dw-pose sequence to do Pose Driven",
+    )
     parser.add_argument(
         "--start_from_ref",
         action="store_true",
         default=False,
-        help="whether set the reference image as the starting point for generation"
+        help="whether set the reference image as the starting point for generation",
     )
     parser.add_argument(
         "--infer_frames",
         type=int,
         default=80,
-        help="Number of frames per clip, 48 or 80 or others (must be multiple of 4) for 14B s2v"
+        help="Number of frames per clip, 48 or 80 or others (must be multiple of 4) for 14B s2v",
     )
 
     args = parser.parse_args()
@@ -249,9 +278,47 @@ def _init_logging(rank):
         logging.basicConfig(
             level=logging.INFO,
             format="[%(asctime)s] %(levelname)s: %(message)s",
-            handlers=[logging.StreamHandler(stream=sys.stdout)])
+            handlers=[logging.StreamHandler(stream=sys.stdout)],
+        )
     else:
         logging.basicConfig(level=logging.ERROR)
+
+
+def _find_wan_model(obj, depth=0, max_depth=4):
+    if isinstance(obj, WanModel):
+        return obj
+    if depth >= max_depth or not hasattr(obj, "__dict__"):
+        return None
+    # Try common attribute names first
+    for name in ("dit", "model", "transformer", "backbone", "wan_model"):
+        if hasattr(obj, name):
+            m = _find_wan_model(getattr(obj, name), depth + 1, max_depth)
+            if m is not None:
+                return m
+    # Fallback: scan attributes
+    for v in obj.__dict__.values():
+        m = _find_wan_model(v, depth + 1, max_depth)
+        if m is not None:
+            return m
+    return None
+
+
+def _maybe_apply_kv_lora(pipeline, args, logger):
+    if not args.kv_lora_adapter:
+        return
+    target = _find_wan_model(pipeline)
+    if target is None:
+        logger.warning(
+            "KV-LoRA: Could not locate WanModel inside pipeline; adapter NOT applied."
+        )
+        return
+    loras = load_peft_adapter(
+        target,
+        path=args.kv_lora_adapter,
+        prefix=args.kv_lora_prefix,
+        alpha=float(args.kv_lora_alpha),
+    )
+    logger.info(f"KV-LoRA: applied {len(loras)} modules from {args.kv_lora_adapter}")
 
 
 def generate(args):
@@ -263,25 +330,24 @@ def generate(args):
 
     if args.offload_model is None:
         args.offload_model = False if world_size > 1 else True
-        logging.info(
-            f"offload_model is not specified, set to {args.offload_model}.")
+        logging.info(f"offload_model is not specified, set to {args.offload_model}.")
     if world_size > 1:
         torch.cuda.set_device(local_rank)
         dist.init_process_group(
-            backend="nccl",
-            init_method="env://",
-            rank=rank,
-            world_size=world_size)
+            backend="nccl", init_method="env://", rank=rank, world_size=world_size
+        )
     else:
         assert not (
             args.t5_fsdp or args.dit_fsdp
-        ), f"t5_fsdp and dit_fsdp are not supported in non-distributed environments."
+        ), "t5_fsdp and dit_fsdp are not supported in non-distributed environments."
         assert not (
             args.ulysses_size > 1
-        ), f"sequence parallel are not supported in non-distributed environments."
+        ), "sequence parallel are not supported in non-distributed environments."
 
     if args.ulysses_size > 1:
-        assert args.ulysses_size == world_size, f"The number of ulysses_size should be equal to the world size."
+        assert (
+            args.ulysses_size == world_size
+        ), "The number of ulysses_size should be equal to the world size."
         init_distributed_group()
 
     if args.use_prompt_extend:
@@ -289,20 +355,25 @@ def generate(args):
             prompt_expander = DashScopePromptExpander(
                 model_name=args.prompt_extend_model,
                 task=args.task,
-                is_vl=args.image is not None)
+                is_vl=args.image is not None,
+            )
         elif args.prompt_extend_method == "local_qwen":
             prompt_expander = QwenPromptExpander(
                 model_name=args.prompt_extend_model,
                 task=args.task,
                 is_vl=args.image is not None,
-                device=rank)
+                device=rank,
+            )
         else:
             raise NotImplementedError(
-                f"Unsupport prompt_extend_method: {args.prompt_extend_method}")
+                f"Unsupport prompt_extend_method: {args.prompt_extend_method}"
+            )
 
     cfg = WAN_CONFIGS[args.task]
     if args.ulysses_size > 1:
-        assert cfg.num_heads % args.ulysses_size == 0, f"`{cfg.num_heads=}` cannot be divided evenly by `{args.ulysses_size=}`."
+        assert (
+            cfg.num_heads % args.ulysses_size == 0
+        ), f"`{cfg.num_heads=}` cannot be divided evenly by `{args.ulysses_size=}`."
 
     logging.info(f"Generation job args: {args}")
     logging.info(f"Generation model config: {cfg}")
@@ -326,10 +397,10 @@ def generate(args):
                 args.prompt,
                 image=img,
                 tar_lang=args.prompt_extend_target_lang,
-                seed=args.base_seed)
-            if prompt_output.status == False:
-                logging.info(
-                    f"Extending prompt failed: {prompt_output.message}")
+                seed=args.base_seed,
+            )
+            if not prompt_output.status:
+                logging.info(f"Extending prompt failed: {prompt_output.message}")
                 logging.info("Falling back to original prompt.")
                 input_prompt = args.prompt
             else:
@@ -355,8 +426,9 @@ def generate(args):
             t5_cpu=args.t5_cpu,
             convert_model_dtype=args.convert_model_dtype,
         )
+        _maybe_apply_kv_lora(wan_t2v, args, logging)
 
-        logging.info(f"Generating video ...")
+        logging.info("Generating video ...")
         video = wan_t2v.generate(
             args.prompt,
             size=SIZE_CONFIGS[args.size],
@@ -366,7 +438,8 @@ def generate(args):
             sampling_steps=args.sample_steps,
             guide_scale=args.sample_guide_scale,
             seed=args.base_seed,
-            offload_model=args.offload_model)
+            offload_model=args.offload_model,
+        )
     elif "ti2v" in args.task:
         logging.info("Creating WanTI2V pipeline.")
         wan_ti2v = wan.WanTI2V(
@@ -380,8 +453,9 @@ def generate(args):
             t5_cpu=args.t5_cpu,
             convert_model_dtype=args.convert_model_dtype,
         )
+        _maybe_apply_kv_lora(wan_ti2v, args, logging)
 
-        logging.info(f"Generating video ...")
+        logging.info("Generating video ...")
         video = wan_ti2v.generate(
             args.prompt,
             img=img,
@@ -393,7 +467,8 @@ def generate(args):
             sampling_steps=args.sample_steps,
             guide_scale=args.sample_guide_scale,
             seed=args.base_seed,
-            offload_model=args.offload_model)
+            offload_model=args.offload_model,
+        )
     elif "s2v" in args.task:
         logging.info("Creating WanS2V pipeline.")
         wan_s2v = wan.WanS2V(
@@ -407,7 +482,8 @@ def generate(args):
             t5_cpu=args.t5_cpu,
             convert_model_dtype=args.convert_model_dtype,
         )
-        logging.info(f"Generating video ...")
+        _maybe_apply_kv_lora(wan_s2v, args, logging)
+        logging.info("Generating video ...")
         video = wan_s2v.generate(
             input_prompt=args.prompt,
             ref_image_path=args.image,
@@ -438,6 +514,7 @@ def generate(args):
             t5_cpu=args.t5_cpu,
             convert_model_dtype=args.convert_model_dtype,
         )
+        _maybe_apply_kv_lora(wan_i2v, args, logging)
 
         logging.info("Generating video ...")
         video = wan_i2v.generate(
@@ -450,15 +527,18 @@ def generate(args):
             sampling_steps=args.sample_steps,
             guide_scale=args.sample_guide_scale,
             seed=args.base_seed,
-            offload_model=args.offload_model)
+            offload_model=args.offload_model,
+        )
 
     if rank == 0:
         if args.save_file is None:
             formatted_time = datetime.now().strftime("%Y%m%d_%H%M%S")
-            formatted_prompt = args.prompt.replace(" ", "_").replace("/",
-                                                                     "_")[:50]
-            suffix = '.mp4'
-            args.save_file = f"{args.task}_{args.size.replace('*','x') if sys.platform=='win32' else args.size}_{args.ulysses_size}_{formatted_prompt}_{formatted_time}" + suffix
+            formatted_prompt = args.prompt.replace(" ", "_").replace("/", "_")[:50]
+            suffix = ".mp4"
+            args.save_file = (
+                f"{args.task}_{args.size.replace('*','x') if sys.platform=='win32' else args.size}_{args.ulysses_size}_{formatted_prompt}_{formatted_time}"
+                + suffix
+            )
 
         logging.info(f"Saving generated video to {args.save_file}")
         save_video(
@@ -467,7 +547,8 @@ def generate(args):
             fps=cfg.sample_fps,
             nrow=1,
             normalize=True,
-            value_range=(-1, 1))
+            value_range=(-1, 1),
+        )
         if "s2v" in args.task:
             merge_video_audio(video_path=args.save_file, audio_path=args.audio)
     del video

--- a/kv_lora_inject.py
+++ b/kv_lora_inject.py
@@ -3,11 +3,11 @@
 # Works without PEFT; produces a PEFT-compatible state dict for adapter_model.safetensors.
 
 from __future__ import annotations
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, List, Tuple, Optional
 
 import torch
 import torch.nn as nn
-from safetensors.torch import save_file as safetensors_save
+from safetensors.torch import save_file as safetensors_save, safe_open
 import math
 
 
@@ -153,3 +153,45 @@ def export_peft_adapter(
             state[key_A] = module.lora_A.weight.detach().cpu()
             state[key_B] = module.lora_B.weight.detach().cpu()
     safetensors_save(state, save_path, metadata={"format": "pt"})
+
+
+# ---------- RUNTIME LOADER ----------
+
+
+def _infer_rank_from_adapter(path: str, prefix: str = "diffusion_model.") -> int:
+    """Read one lora_A tensor to infer the LoRA rank."""
+    with safe_open(path, framework="pt", device="cpu") as f:
+        for k in f.keys():
+            if k.endswith(".lora_A.weight") and k.startswith(prefix):
+                # lora_A has shape [rank, in_features]
+                return int(f.get_tensor(k).shape[0])
+    raise RuntimeError("Could not infer LoRA rank from adapter file.")
+
+
+def load_peft_adapter(
+    model: nn.Module,
+    path: str,
+    prefix: str = "diffusion_model.",
+    alpha: float = 32.0,
+    dropout: float = 0.0,
+    blocks_range: Optional[Tuple[int, int]] = None,
+) -> Dict[str, LoRALinear]:
+    """
+    Inject KV LoRA into the model with the correct rank and load weights from `path`.
+    Returns: dict of injected modules, same keys as inject_lora_kv.
+    """
+
+    rank = _infer_rank_from_adapter(path, prefix=prefix)
+    loras = inject_lora_kv(
+        model, rank=rank, alpha=alpha, dropout=dropout, blocks_range=blocks_range
+    )
+    # load weights
+    with safe_open(path, framework="pt", device="cpu") as f:
+        for name, module in model.named_modules():
+            if isinstance(module, LoRALinear):
+                key_A = f"{prefix}{name}.lora_A.weight"
+                key_B = f"{prefix}{name}.lora_B.weight"
+                module.lora_A.weight.copy_(f.get_tensor(key_A))
+                module.lora_B.weight.copy_(f.get_tensor(key_B))
+                module.enabled = True
+    return loras

--- a/train_kv_lora_distill.py
+++ b/train_kv_lora_distill.py
@@ -21,6 +21,7 @@ from typing import List, Tuple
 from datetime import datetime, timezone
 import shutil
 from tqdm import tqdm
+import time
 
 import torch
 from torch.optim import AdamW
@@ -330,6 +331,10 @@ def train(args: argparse.Namespace) -> None:
     params = lora_parameters(model)
     optim = AdamW(params, lr=args.lr, weight_decay=0.0)
 
+    ema = None
+    ema_beta = 0.98  # smoothing
+    last_print = time.perf_counter()
+
     for epoch in range(args.epochs):
         pbar = tqdm(loader, desc=f"epoch {epoch+1}/{args.epochs}", leave=True)
         for batch_prompts in pbar:
@@ -366,9 +371,31 @@ def train(args: argparse.Namespace) -> None:
             loss.backward()
             torch.nn.utils.clip_grad_norm_(params, 1.0)
             optim.step()
-            steps_total += 1
             # progress
             loss_val = float(loss.detach().item())
+            ema = (
+                (ema_beta * ema + (1 - ema_beta) * loss_val)
+                if ema is not None
+                else loss_val
+            )
+            steps_total += 1
+            if steps_total % 50 == 0:
+                now = time.perf_counter()
+                dt = now - last_print
+                it_per_s = 50.0 / max(dt, 1e-6)
+                last_print = now
+                # Tiny delta budget check
+                tot_sq, base_sq = 0.0, 0.0
+                with torch.no_grad():
+                    for m in model.modules():
+                        if hasattr(m, "base") and hasattr(m, "lora_A"):
+                            dW = (m.lora_B.weight @ m.lora_A.weight) * m.scaling
+                            tot_sq += float((dW**2).sum().item())
+                            base_sq += float((m.base.weight**2).sum().item())
+                delta_ratio = (tot_sq**0.5 / base_sq**0.5) if base_sq > 0 else 0.0
+                print(
+                    f"[{epoch+1}/{args.epochs}] step={steps_total} loss={loss_val:.1f} ema={ema:.1f} it/s={it_per_s:.2f} ΔW/W={delta_ratio:.3e}"
+                )
             pbar.set_postfix_str(f"loss={loss_val:.5f}")
             _append_progress(epoch=epoch + 1, step=steps_total, loss=loss_val)
 
@@ -381,6 +408,52 @@ def train(args: argparse.Namespace) -> None:
                 shutil.copy2(
                     ck_step, os.path.join(args.out_dir, "adapter_latest.safetensors")
                 )
+                print(f"[ckpt] wrote {ck_step}")
+                # Optional sampling
+                if (
+                    args.sample_every_steps > 0
+                    and args.sample_prompts_file
+                    and (steps_total % args.sample_every_steps == 0)
+                ):
+                    try:
+                        import subprocess
+                        import shlex
+
+                        with open(args.sample_prompts_file, "r", encoding="utf-8") as f:
+                            prompts = [ln.strip() for ln in f if ln.strip()][
+                                : args.sample_n
+                            ]
+                        samp_dir = os.path.join(
+                            args.out_dir, "sample", f"step_{steps_total:07d}"
+                        )
+                        os.makedirs(samp_dir, exist_ok=True)
+                        env = os.environ.copy()
+                        env["WAN_USE_BRIDGE"] = "1"
+                        env["WAN_BRIDGE_CKPT"] = args.bridge_ckpt
+                        env["WAN_BRIDGE_LLM_DIR"] = args.llm_dir
+                        env["WAN_BRIDGE_GLOBAL_SCALE"] = str(args.global_scale)
+                        gen = os.path.join(
+                            Path(__file__).parent,
+                            "inference",
+                            "Wan2.2",
+                            "generate.py",
+                        )
+                        for i, prompt in enumerate(prompts):
+                            cmd_base = (
+                                f'python "{gen}" --task {args.sample_task} --ckpt_dir "{args.transformer_weights_dir or os.path.dirname(args.transformer_weights)}" '
+                                f"--size {args.sample_size} --frame_num {args.sample_frame_num} --sample_steps {args.sample_steps} "
+                                f'--sample_guide_scale {args.sample_guide_scale} --base_seed {args.sample_seed} --prompt "{prompt}" '
+                                f'--save_file "{os.path.join(samp_dir, f"p{i:02d}_baseline.mp4")}"'
+                            )
+                            subprocess.run(shlex.split(cmd_base), env=env, check=False)
+                            cmd_lora = (
+                                cmd_base
+                                + f' --kv_lora_adapter "{ck_step}" --kv_lora_prefix {args.adapter_prefix} --kv_lora_alpha {args.alpha}'
+                            )
+                            cmd_lora = cmd_lora.replace("baseline.mp4", "lora.mp4")
+                            subprocess.run(shlex.split(cmd_lora), env=env, check=False)
+                    except Exception as e:
+                        print(f"[sample] failed to auto-sample: {e}")
 
         print(f"Epoch {epoch+1}/{args.epochs} - loss {loss.item():.4f}")
         # epoch checkpoint
@@ -501,6 +574,31 @@ def build_argparser() -> argparse.ArgumentParser:
         default=0,
         help="If >0, write adapter_step_*.safetensors every N steps.",
     )
+    # On-save sampling
+    p.add_argument(
+        "--sample_every_steps",
+        type=int,
+        default=0,
+        help="0=off; sample every N steps when a checkpoint is saved",
+    )
+    p.add_argument(
+        "--sample_prompts_file",
+        type=str,
+        default=None,
+        help="Text file of prompts; first K are used per sample",
+    )
+    p.add_argument(
+        "--sample_n",
+        type=int,
+        default=2,
+        help="How many prompts from the file to sample each time",
+    )
+    p.add_argument("--sample_task", type=str, default="ti2v-5B")
+    p.add_argument("--sample_size", type=str, default="1280*720")
+    p.add_argument("--sample_steps", type=int, default=50)
+    p.add_argument("--sample_guide_scale", type=float, default=5.5)
+    p.add_argument("--sample_frame_num", type=int, default=33)
+    p.add_argument("--sample_seed", type=int, default=12345)
     p.add_argument(
         "--save_every_epochs",
         type=int,


### PR DESCRIPTION
## Summary
- add runtime loader for KV-LoRA adapters
- wire `--kv_lora_adapter` into Wan 2.2 generator
- enhance training logs and optionally auto-sample checkpoints

## Testing
- `black --check kv_lora_inject.py inference/Wan2.2/generate.py train_kv_lora_distill.py`
- `ruff check kv_lora_inject.py inference/Wan2.2/generate.py train_kv_lora_distill.py`
- `pytest -q` *(fails: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/workspace/models/MythoMax-L2-13B')*

------
https://chatgpt.com/codex/tasks/task_e_68af9562c8148323afd485fa8c4f517c