### PR TITLE
feat: support runtime KV‑LoRA adapter loading

### DIFF
--- a/inference/Wan2.2/generate.py
+++ b/inference/Wan2.2/generate.py
@@ -7,17 +7,22 @@ import warnings
 from datetime import datetime
 import random
 
+# Allow running without PYTHONPATH set to repo root
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+try:
+    from kv_lora_inject import load_peft_adapter
+except Exception:
+    load_peft_adapter = None
+
 import torch
 import torch.distributed as dist
 from PIL import Image
 
 import wan
-from wan.modules.model import WanModel
 from wan.configs import MAX_AREA_CONFIGS, SIZE_CONFIGS, SUPPORTED_SIZES, WAN_CONFIGS
 from wan.distributed.util import init_distributed_group
 from wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander
 from wan.utils.utils import merge_video_audio, save_video, str2bool
-from kv_lora_inject import load_peft_adapter
 
 warnings.filterwarnings("ignore")
 
@@ -215,24 +220,18 @@ def _parse_args():
         default=False,
         help="Whether to convert model paramerters dtype.",
     )
-    # KV-LoRA (KV-only cross-attn) adapter support
+    # KV-LoRA adapter support
     parser.add_argument(
-        "--kv_lora_adapter",
+        "--lora_adapter_path",
         type=str,
         default=None,
-        help="Path to a KV-LoRA adapter .safetensors (KV-only cross-attn).",
+        help="Path to KV-LoRA adapter .safetensors (cross_attn K/V).",
     )
     parser.add_argument(
-        "--kv_lora_prefix",
-        type=str,
-        default="diffusion_model.",
-        help="Key prefix inside the adapter file (e.g., diffusion_model. or transformer.).",
-    )
-    parser.add_argument(
-        "--kv_lora_alpha",
+        "--lora_alpha",
         type=float,
         default=32.0,
-        help="LoRA alpha used during training; controls scaling at runtime.",
+        help="LoRA alpha used during training (scales A@B).",
     )
 
     # following args only works for s2v
@@ -284,41 +283,27 @@ def _init_logging(rank):
         logging.basicConfig(level=logging.ERROR)
 
 
-def _find_wan_model(obj, depth=0, max_depth=4):
-    if isinstance(obj, WanModel):
-        return obj
-    if depth >= max_depth or not hasattr(obj, "__dict__"):
-        return None
-    # Try common attribute names first
-    for name in ("dit", "model", "transformer", "backbone", "wan_model"):
-        if hasattr(obj, name):
-            m = _find_wan_model(getattr(obj, name), depth + 1, max_depth)
-            if m is not None:
-                return m
-    # Fallback: scan attributes
-    for v in obj.__dict__.values():
-        m = _find_wan_model(v, depth + 1, max_depth)
-        if m is not None:
-            return m
-    return None
-
-
-def _maybe_apply_kv_lora(pipeline, args, logger):
-    if not args.kv_lora_adapter:
+def _maybe_load_kv_lora(pipeline, args, logger):
+    if not args.lora_adapter_path:
         return
-    target = _find_wan_model(pipeline)
-    if target is None:
+    if load_peft_adapter is None:
         logger.warning(
-            "KV-LoRA: Could not locate WanModel inside pipeline; adapter NOT applied."
+            "kv_lora_inject.load_peft_adapter not available; skipping --lora_adapter_path."
         )
         return
-    loras = load_peft_adapter(
+    target = getattr(pipeline, "dit", None) or getattr(pipeline, "model", None)
+    if target is None:
+        logger.warning(
+            "Could not locate underlying DiT (no .dit or .model); skipping --lora_adapter_path."
+        )
+        return
+    load_peft_adapter(
         target,
-        path=args.kv_lora_adapter,
-        prefix=args.kv_lora_prefix,
-        alpha=float(args.kv_lora_alpha),
+        path=args.lora_adapter_path,
+        prefix="diffusion_model.",
+        alpha=args.lora_alpha,
     )
-    logger.info(f"KV-LoRA: applied {len(loras)} modules from {args.kv_lora_adapter}")
+    logger.info(f"Loaded KV-LoRA adapter: {args.lora_adapter_path}")
 
 
 def generate(args):
@@ -426,7 +411,7 @@ def generate(args):
             t5_cpu=args.t5_cpu,
             convert_model_dtype=args.convert_model_dtype,
         )
-        _maybe_apply_kv_lora(wan_t2v, args, logging)
+        _maybe_load_kv_lora(wan_t2v, args, logging)
 
         logging.info("Generating video ...")
         video = wan_t2v.generate(
@@ -453,7 +438,7 @@ def generate(args):
             t5_cpu=args.t5_cpu,
             convert_model_dtype=args.convert_model_dtype,
         )
-        _maybe_apply_kv_lora(wan_ti2v, args, logging)
+        _maybe_load_kv_lora(wan_ti2v, args, logging)
 
         logging.info("Generating video ...")
         video = wan_ti2v.generate(
@@ -482,7 +467,7 @@ def generate(args):
             t5_cpu=args.t5_cpu,
             convert_model_dtype=args.convert_model_dtype,
         )
-        _maybe_apply_kv_lora(wan_s2v, args, logging)
+        _maybe_load_kv_lora(wan_s2v, args, logging)
         logging.info("Generating video ...")
         video = wan_s2v.generate(
             input_prompt=args.prompt,
@@ -514,7 +499,7 @@ def generate(args):
             t5_cpu=args.t5_cpu,
             convert_model_dtype=args.convert_model_dtype,
         )
-        _maybe_apply_kv_lora(wan_i2v, args, logging)
+        _maybe_load_kv_lora(wan_i2v, args, logging)
 
         logging.info("Generating video ...")
         video = wan_i2v.generate(

--- a/kv_lora_inject.py
+++ b/kv_lora_inject.py
@@ -3,7 +3,7 @@
 # Works without PEFT; produces a PEFT-compatible state dict for adapter_model.safetensors.
 
 from __future__ import annotations
-from typing import Dict, Iterable, List, Tuple, Optional
+from typing import Dict, Iterable, List, Tuple
 
 import torch
 import torch.nn as nn
@@ -155,17 +155,26 @@ def export_peft_adapter(
     safetensors_save(state, save_path, metadata={"format": "pt"})
 
 
-# ---------- RUNTIME LOADER ----------
+# ---- Runtime loader (PEFT-ish) ----
 
 
-def _infer_rank_from_adapter(path: str, prefix: str = "diffusion_model.") -> int:
-    """Read one lora_A tensor to infer the LoRA rank."""
-    with safe_open(path, framework="pt", device="cpu") as f:
-        for k in f.keys():
-            if k.endswith(".lora_A.weight") and k.startswith(prefix):
-                # lora_A has shape [rank, in_features]
-                return int(f.get_tensor(k).shape[0])
-    raise RuntimeError("Could not infer LoRA rank from adapter file.")
+def _get_submodule(root: nn.Module, path: str) -> nn.Module:
+    """Traverse a dotted path like 'blocks.0.cross_attn.k'."""
+    mod = root
+    for part in path.split("."):
+        if part.isdigit():
+            mod = mod[int(part)]  # ModuleList / list
+        else:
+            mod = getattr(mod, part)
+    return mod
+
+
+def _set_submodule(root: nn.Module, path: str, new: nn.Module) -> None:
+    parts = path.split(".")
+    parent = root
+    for part in parts[:-1]:
+        parent = parent[int(part)] if part.isdigit() else getattr(parent, part)
+    setattr(parent, parts[-1], new)
 
 
 def load_peft_adapter(
@@ -174,24 +183,51 @@ def load_peft_adapter(
     prefix: str = "diffusion_model.",
     alpha: float = 32.0,
     dropout: float = 0.0,
-    blocks_range: Optional[Tuple[int, int]] = None,
 ) -> Dict[str, LoRALinear]:
     """
-    Inject KV LoRA into the model with the correct rank and load weights from `path`.
-    Returns: dict of injected modules, same keys as inject_lora_kv.
+    Load a KV-only LoRA adapter saved by export_peft_adapter(...).
+    Returns: dict mapping 'blocks.{i}.cross_attn.{k|v}' -> LoRALinear
     """
-
-    rank = _infer_rank_from_adapter(path, prefix=prefix)
-    loras = inject_lora_kv(
-        model, rank=rank, alpha=alpha, dropout=dropout, blocks_range=blocks_range
-    )
-    # load weights
+    # Read tensors
+    tensors: Dict[str, torch.Tensor] = {}
     with safe_open(path, framework="pt", device="cpu") as f:
-        for name, module in model.named_modules():
-            if isinstance(module, LoRALinear):
-                key_A = f"{prefix}{name}.lora_A.weight"
-                key_B = f"{prefix}{name}.lora_B.weight"
-                module.lora_A.weight.copy_(f.get_tensor(key_A))
-                module.lora_B.weight.copy_(f.get_tensor(key_B))
-                module.enabled = True
-    return loras
+        for k in f.keys():
+            tensors[k] = f.get_tensor(k)
+
+    # Group by module path
+    groups: Dict[str, Dict[str, torch.Tensor]] = {}
+    for k, t in tensors.items():
+        if not k.startswith(prefix):
+            continue
+        tail = k[len(prefix) :]
+        if tail.endswith(".lora_A.weight"):
+            mpath = tail[: -len(".lora_A.weight")]
+            groups.setdefault(mpath, {})["A"] = t
+        elif tail.endswith(".lora_B.weight"):
+            mpath = tail[: -len(".lora_B.weight")]
+            groups.setdefault(mpath, {})["B"] = t
+
+    # Inject wrappers and load weights
+    loaded: Dict[str, LoRALinear] = {}
+    for mpath, parts in groups.items():
+        A = parts.get("A")
+        B = parts.get("B")
+        if A is None or B is None:
+            continue
+        rank = A.shape[1]
+        base = _get_submodule(model, mpath)
+        if isinstance(base, LoRALinear):
+            lora = base
+        else:
+            assert isinstance(
+                base, nn.Linear
+            ), f"Expected nn.Linear at {mpath}, got {type(base)}"
+            lora = LoRALinear(base, rank=rank, alpha=alpha, dropout=dropout)
+            _set_submodule(model, mpath, lora)
+        with torch.no_grad():
+            lora.lora_A.weight.copy_(A)
+            lora.lora_B.weight.copy_(B)
+            lora.enabled = True
+        loaded[mpath] = lora
+
+    return loaded


### PR DESCRIPTION
## Summary
- add PEFT-style `load_peft_adapter` that wraps cross-attn K/V projections and loads weights
- enable `generate.py` to load KV-LoRA adapters via `--lora_adapter_path` and `--lora_alpha`

## Testing
- `ruff check kv_lora_inject.py inference/Wan2.2/generate.py`
- `black kv_lora_inject.py inference/Wan2.2/generate.py`
- `pytest` *(fails: Repo id must be in the form 'repo_name' or 'namespace/repo_name')*


------
https://chatgpt.com/codex/tasks/task_e_68afa3d91ce48323a58ca39f40f45af4