### PR TITLE
fix kv-lora adapter loading

### DIFF
--- a/inference/Wan2.2/generate.py
+++ b/inference/Wan2.2/generate.py
@@ -224,6 +224,8 @@ def _parse_args():
     # KV-LoRA adapter support
     parser.add_argument(
         "--lora_adapter_path",
+        "--lora_adapter",
+        dest="lora_adapter_path",
         type=str,
         default=None,
         help="Path to KV-LoRA adapter .safetensors (cross_attn K/V).",
@@ -285,29 +287,43 @@ def _init_logging(rank):
 
 
 def _maybe_load_kv_lora(pipeline, args, logger):
+    """Inject and load KV-LoRA into the Wan transformer inside the pipeline."""
     if not args.lora_adapter_path:
         return
     if load_peft_adapter is None or inject_lora_kv is None:
         logger.warning("kv_lora_inject not available; skipping --lora_adapter_path.")
         return
+
+    # 1) Find the WanModel (has .blocks[..].cross_attn.{k,v})
     target = getattr(pipeline, "dit", None) or getattr(pipeline, "model", None)
     if target is None:
-        logger.warning(
-            "Could not locate underlying DiT (no .dit or .model); skipping --lora_adapter_path."
-        )
+        logger.warning("No .dit/.model found on pipeline; cannot apply LoRA.")
         return
+    # WanModel in training exposed .blocks directly; some builds wrap it in .diffusion_model.
     base = getattr(target, "diffusion_model", None)
+    if base is None and hasattr(target, "blocks"):
+        base = target
     if base is None:
-        logger.warning("Target has no diffusion_model; skipping --lora_adapter_path.")
+        # Heuristic fallback: walk submodules to find something with .blocks
+        for _, m in target.named_modules():
+            if hasattr(m, "blocks"):
+                base = m
+                break
+    if base is None:
+        logger.warning("Could not locate a transformer with `.blocks`; skipping LoRA.")
         return
-    inject_lora_kv(base, rank=8, alpha=args.lora_alpha)
-    load_peft_adapter(
-        target,
+
+    # 2) Inject LoRA wrappers then load weights
+    loras = inject_lora_kv(base, rank=8, alpha=args.lora_alpha)
+    loaded = load_peft_adapter(
+        base,
         path=args.lora_adapter_path,
         prefix="diffusion_model.",
         alpha=args.lora_alpha,
     )
-    logger.info(f"Loaded KV-LoRA adapter: {args.lora_adapter_path}")
+    logger.info(
+        f"Injected {len(loras)} KV-LoRA modules; loaded {len(loaded)} from {args.lora_adapter_path}"
+    )
 
 
 def generate(args):

--- a/train_kv_lora_distill.py
+++ b/train_kv_lora_distill.py
@@ -498,7 +498,7 @@ def train(args: argparse.Namespace) -> None:
                             subprocess.run(shlex.split(cmd_base), env=env, check=False)
                             cmd_lora = (
                                 cmd_base
-                                + f' --kv_lora_adapter "{ck_step}" --kv_lora_prefix {args.adapter_prefix} --kv_lora_alpha {args.alpha}'
+                                + f' --lora_adapter_path "{ck_step}" --lora_alpha {args.alpha}'
                             )
                             cmd_lora = cmd_lora.replace("baseline.mp4", "lora.mp4")
                             subprocess.run(shlex.split(cmd_lora), env=env, check=False)


### PR DESCRIPTION
## Summary
- make KV-LoRA injection locate Wan transformer robustly and report loaded modules
- add `--lora_adapter` CLI alias and update trainer auto-sampler flags

## Testing
- `python -m black inference/Wan2.2/generate.py train_kv_lora_distill.py`
- `ruff check inference/Wan2.2/generate.py train_kv_lora_distill.py`
- `pytest -q` *(fails: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/workspace/models/MythoMax-L2-13B')*

------
https://chatgpt.com/codex/tasks/task_e_68afaeb124e48323839a59d884e551eb