### PR TITLE
Offload text encoders to CPU and streamline sampling

### DIFF
--- a/inference/Wan2.2/wan/image2video.py
+++ b/inference/Wan2.2/wan/image2video.py
@@ -11,7 +11,6 @@ from functools import partial
 
 import numpy as np
 import torch
-import torch.cuda.amp as amp
 import torch.distributed as dist
 import torchvision.transforms.functional as TF
 from tqdm import tqdm
@@ -88,7 +87,7 @@ class WanI2V:
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,
-            device=torch.device('cpu'),
+            device=torch.device("cpu"),
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
             shard_fn=shard_fn if t5_fsdp else None,
@@ -98,26 +97,31 @@ class WanI2V:
         self.patch_size = config.patch_size
         self.vae = Wan2_1_VAE(
             vae_pth=os.path.join(checkpoint_dir, config.vae_checkpoint),
-            device=self.device)
+            device=self.device,
+        )
 
         logging.info(f"Creating WanModel from {checkpoint_dir}")
         self.low_noise_model = WanModel.from_pretrained(
-            checkpoint_dir, subfolder=config.low_noise_checkpoint)
+            checkpoint_dir, subfolder=config.low_noise_checkpoint
+        )
         self.low_noise_model = self._configure_model(
             model=self.low_noise_model,
             use_sp=use_sp,
             dit_fsdp=dit_fsdp,
             shard_fn=shard_fn,
-            convert_model_dtype=convert_model_dtype)
+            convert_model_dtype=convert_model_dtype,
+        )
 
         self.high_noise_model = WanModel.from_pretrained(
-            checkpoint_dir, subfolder=config.high_noise_checkpoint)
+            checkpoint_dir, subfolder=config.high_noise_checkpoint
+        )
         self.high_noise_model = self._configure_model(
             model=self.high_noise_model,
             use_sp=use_sp,
             dit_fsdp=dit_fsdp,
             shard_fn=shard_fn,
-            convert_model_dtype=convert_model_dtype)
+            convert_model_dtype=convert_model_dtype,
+        )
         if use_sp:
             self.sp_size = get_world_size()
         else:
@@ -125,8 +129,7 @@ class WanI2V:
 
         self.sample_neg_prompt = config.sample_neg_prompt
 
-    def _configure_model(self, model, use_sp, dit_fsdp, shard_fn,
-                         convert_model_dtype):
+    def _configure_model(self, model, use_sp, dit_fsdp, shard_fn, convert_model_dtype):
         """
         Configures a model object. This includes setting evaluation modes,
         applying distributed parallel strategy, and handling device placement.
@@ -153,7 +156,8 @@ class WanI2V:
         if use_sp:
             for block in model.blocks:
                 block.self_attn.forward = types.MethodType(
-                    sp_attn_forward, block.self_attn)
+                    sp_attn_forward, block.self_attn
+                )
             model.forward = types.MethodType(sp_dit_forward, model)
 
         if dist.is_initialized():
@@ -187,34 +191,38 @@ class WanI2V:
                 The active model on the target device for the current timestep.
         """
         if t.item() >= boundary:
-            required_model_name = 'high_noise_model'
-            offload_model_name = 'low_noise_model'
+            required_model_name = "high_noise_model"
+            offload_model_name = "low_noise_model"
         else:
-            required_model_name = 'low_noise_model'
-            offload_model_name = 'high_noise_model'
+            required_model_name = "low_noise_model"
+            offload_model_name = "high_noise_model"
         if offload_model or self.init_on_cpu:
-            if next(getattr(
-                    self,
-                    offload_model_name).parameters()).device.type == 'cuda':
-                getattr(self, offload_model_name).to('cpu')
-            if next(getattr(
-                    self,
-                    required_model_name).parameters()).device.type == 'cpu':
+            if (
+                next(getattr(self, offload_model_name).parameters()).device.type
+                == "cuda"
+            ):
+                getattr(self, offload_model_name).to("cpu")
+            if (
+                next(getattr(self, required_model_name).parameters()).device.type
+                == "cpu"
+            ):
                 getattr(self, required_model_name).to(self.device)
         return getattr(self, required_model_name)
 
-    def generate(self,
-                 input_prompt,
-                 img,
-                 max_area=720 * 1280,
-                 frame_num=81,
-                 shift=5.0,
-                 sample_solver='unipc',
-                 sampling_steps=40,
-                 guide_scale=5.0,
-                 n_prompt="",
-                 seed=-1,
-                 offload_model=True):
+    def generate(
+        self,
+        input_prompt,
+        img,
+        max_area=720 * 1280,
+        frame_num=81,
+        shift=5.0,
+        sample_solver="unipc",
+        sampling_steps=40,
+        guide_scale=5.0,
+        n_prompt="",
+        seed=-1,
+        offload_model=True,
+    ):
         r"""
         Generates video frames from input image and text prompt using diffusion process.
 
@@ -254,24 +262,37 @@ class WanI2V:
                 - W: Frame width from max_area)
         """
         # preprocess
-        guide_scale = (guide_scale, guide_scale) if isinstance(
-            guide_scale, float) else guide_scale
+        guide_scale = (
+            (guide_scale, guide_scale)
+            if isinstance(guide_scale, float)
+            else guide_scale
+        )
         img = TF.to_tensor(img).sub_(0.5).div_(0.5).to(self.device)
 
         F = frame_num
         h, w = img.shape[1:]
         aspect_ratio = h / w
         lat_h = round(
-            np.sqrt(max_area * aspect_ratio) // self.vae_stride[1] //
-            self.patch_size[1] * self.patch_size[1])
+            np.sqrt(max_area * aspect_ratio)
+            // self.vae_stride[1]
+            // self.patch_size[1]
+            * self.patch_size[1]
+        )
         lat_w = round(
-            np.sqrt(max_area / aspect_ratio) // self.vae_stride[2] //
-            self.patch_size[2] * self.patch_size[2])
+            np.sqrt(max_area / aspect_ratio)
+            // self.vae_stride[2]
+            // self.patch_size[2]
+            * self.patch_size[2]
+        )
         h = lat_h * self.vae_stride[1]
         w = lat_w * self.vae_stride[2]
 
-        max_seq_len = ((F - 1) // self.vae_stride[0] + 1) * lat_h * lat_w // (
-            self.patch_size[1] * self.patch_size[2])
+        max_seq_len = (
+            ((F - 1) // self.vae_stride[0] + 1)
+            * lat_h
+            * lat_w
+            // (self.patch_size[1] * self.patch_size[2])
+        )
         max_seq_len = int(math.ceil(max_seq_len / self.sp_size)) * self.sp_size
 
         seed = seed if seed >= 0 else random.randint(0, sys.maxsize)
@@ -284,14 +305,14 @@ class WanI2V:
             lat_w,
             dtype=torch.float32,
             generator=seed_g,
-            device=self.device)
+            device=self.device,
+        )
 
         msk = torch.ones(1, F, lat_h, lat_w, device=self.device)
         msk[:, 1:] = 0
-        msk = torch.concat([
-            torch.repeat_interleave(msk[:, 0:1], repeats=4, dim=1), msk[:, 1:]
-        ],
-                           dim=1)
+        msk = torch.concat(
+            [torch.repeat_interleave(msk[:, 0:1], repeats=4, dim=1), msk[:, 1:]], dim=1
+        )
         msk = msk.view(1, msk.shape[1] // 4, 4, lat_h, lat_w)
         msk = msk.transpose(1, 2)[0]
 
@@ -299,65 +320,74 @@ class WanI2V:
             n_prompt = self.sample_neg_prompt
 
         # preprocess
-        if not self.t5_cpu:
+        # Honor CPU text-encoder when requested to save VRAM
+        if getattr(self, "t5_cpu", False):
+            try:
+                self.text_encoder.model.to("cpu")
+            except AttributeError:
+                pass
+            context = self.text_encoder([input_prompt], torch.device("cpu"))
+            context_null = self.text_encoder([n_prompt], torch.device("cpu"))
+            context = [t.to(self.device) for t in context]
+            context_null = [t.to(self.device) for t in context_null]
+        else:
             self.text_encoder.model.to(self.device)
             context = self.text_encoder([input_prompt], self.device)
             context_null = self.text_encoder([n_prompt], self.device)
             if offload_model:
                 self.text_encoder.model.cpu()
-        else:
-            context = self.text_encoder([input_prompt], torch.device('cpu'))
-            context_null = self.text_encoder([n_prompt], torch.device('cpu'))
-            context = [t.to(self.device) for t in context]
-            context_null = [t.to(self.device) for t in context_null]
 
-        y = self.vae.encode([
-            torch.concat([
-                torch.nn.functional.interpolate(
-                    img[None].cpu(), size=(h, w), mode='bicubic').transpose(
-                        0, 1),
-                torch.zeros(3, F - 1, h, w)
-            ],
-                         dim=1).to(self.device)
-        ])[0]
+        y = self.vae.encode(
+            [
+                torch.concat(
+                    [
+                        torch.nn.functional.interpolate(
+                            img[None].cpu(), size=(h, w), mode="bicubic"
+                        ).transpose(0, 1),
+                        torch.zeros(3, F - 1, h, w),
+                    ],
+                    dim=1,
+                ).to(self.device)
+            ]
+        )[0]
         y = torch.concat([msk, y])
 
         @contextmanager
         def noop_no_sync():
             yield
 
-        no_sync_low_noise = getattr(self.low_noise_model, 'no_sync',
-                                    noop_no_sync)
-        no_sync_high_noise = getattr(self.high_noise_model, 'no_sync',
-                                     noop_no_sync)
+        no_sync_low_noise = getattr(self.low_noise_model, "no_sync", noop_no_sync)
+        no_sync_high_noise = getattr(self.high_noise_model, "no_sync", noop_no_sync)
 
         # evaluation mode
         with (
-                torch.amp.autocast('cuda', dtype=self.param_dtype),
-                torch.no_grad(),
-                no_sync_low_noise(),
-                no_sync_high_noise(),
+            torch.amp.autocast("cuda", dtype=self.param_dtype),
+            torch.no_grad(),
+            no_sync_low_noise(),
+            no_sync_high_noise(),
         ):
             boundary = self.boundary * self.num_train_timesteps
 
-            if sample_solver == 'unipc':
+            if sample_solver == "unipc":
                 sample_scheduler = FlowUniPCMultistepScheduler(
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
-                    use_dynamic_shifting=False)
+                    use_dynamic_shifting=False,
+                )
                 sample_scheduler.set_timesteps(
-                    sampling_steps, device=self.device, shift=shift)
+                    sampling_steps, device=self.device, shift=shift
+                )
                 timesteps = sample_scheduler.timesteps
-            elif sample_solver == 'dpm++':
+            elif sample_solver == "dpm++":
                 sample_scheduler = FlowDPMSolverMultistepScheduler(
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
-                    use_dynamic_shifting=False)
+                    use_dynamic_shifting=False,
+                )
                 sampling_sigmas = get_sampling_sigmas(sampling_steps, shift)
                 timesteps, _ = retrieve_timesteps(
-                    sample_scheduler,
-                    device=self.device,
-                    sigmas=sampling_sigmas)
+                    sample_scheduler, device=self.device, sigmas=sampling_sigmas
+                )
             else:
                 raise NotImplementedError("Unsupported solver.")
 
@@ -365,15 +395,15 @@ class WanI2V:
             latent = noise
 
             arg_c = {
-                'context': [context[0]],
-                'seq_len': max_seq_len,
-                'y': [y],
+                "context": [context[0]],
+                "seq_len": max_seq_len,
+                "y": [y],
             }
 
             arg_null = {
-                'context': context_null,
-                'seq_len': max_seq_len,
-                'y': [y],
+                "context": context_null,
+                "seq_len": max_seq_len,
+                "y": [y],
             }
 
             if offload_model:
@@ -385,28 +415,28 @@ class WanI2V:
 
                 timestep = torch.stack(timestep).to(self.device)
 
-                model = self._prepare_model_for_timestep(
-                    t, boundary, offload_model)
-                sample_guide_scale = guide_scale[1] if t.item(
-                ) >= boundary else guide_scale[0]
+                model = self._prepare_model_for_timestep(t, boundary, offload_model)
+                sample_guide_scale = (
+                    guide_scale[1] if t.item() >= boundary else guide_scale[0]
+                )
 
-                noise_pred_cond = model(
-                    latent_model_input, t=timestep, **arg_c)[0]
+                noise_pred_cond = model(latent_model_input, t=timestep, **arg_c)[0]
                 if offload_model:
                     torch.cuda.empty_cache()
-                noise_pred_uncond = model(
-                    latent_model_input, t=timestep, **arg_null)[0]
+                noise_pred_uncond = model(latent_model_input, t=timestep, **arg_null)[0]
                 if offload_model:
                     torch.cuda.empty_cache()
                 noise_pred = noise_pred_uncond + sample_guide_scale * (
-                    noise_pred_cond - noise_pred_uncond)
+                    noise_pred_cond - noise_pred_uncond
+                )
 
                 temp_x0 = sample_scheduler.step(
                     noise_pred.unsqueeze(0),
                     t,
                     latent.unsqueeze(0),
                     return_dict=False,
-                    generator=seed_g)[0]
+                    generator=seed_g,
+                )[0]
                 latent = temp_x0.squeeze(0)
 
                 x0 = [latent]

--- a/inference/Wan2.2/wan/speech2video.py
+++ b/inference/Wan2.2/wan/speech2video.py
@@ -6,15 +6,12 @@ import os
 import random
 import sys
 import types
-from contextlib import contextmanager
 from copy import deepcopy
 from functools import partial
 
 import numpy as np
 import torch
-import torch.cuda.amp as amp
 import torch.distributed as dist
-import torchvision.transforms.functional as TF
 from decord import VideoReader
 from PIL import Image
 from safetensors import safe_open
@@ -22,7 +19,6 @@ from torchvision import transforms
 from tqdm import tqdm
 
 from .distributed.fsdp import shard_model
-from .distributed.sequence_parallel import sp_attn_forward, sp_dit_forward
 from .distributed.util import get_world_size
 from .modules.s2v.audio_encoder import AudioEncoder
 from .modules.s2v.model_s2v import WanModel_S2V, sp_attn_forward_s2v
@@ -101,7 +97,7 @@ class WanS2V:
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,
-            device=torch.device('cpu'),
+            device=torch.device("cpu"),
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
             shard_fn=shard_fn if t5_fsdp else None,
@@ -109,28 +105,30 @@ class WanS2V:
 
         self.vae = Wan2_1_VAE(
             vae_pth=os.path.join(checkpoint_dir, config.vae_checkpoint),
-            device=self.device)
+            device=self.device,
+        )
 
         logging.info(f"Creating WanModel from {checkpoint_dir}")
         if not dit_fsdp:
             self.noise_model = WanModel_S2V.from_pretrained(
-                checkpoint_dir,
-                torch_dtype=self.param_dtype,
-                device_map=self.device)
+                checkpoint_dir, torch_dtype=self.param_dtype, device_map=self.device
+            )
         else:
             self.noise_model = WanModel_S2V.from_pretrained(
-                checkpoint_dir, torch_dtype=self.param_dtype)
+                checkpoint_dir, torch_dtype=self.param_dtype
+            )
 
         self.noise_model = self._configure_model(
             model=self.noise_model,
             use_sp=use_sp,
             dit_fsdp=dit_fsdp,
             shard_fn=shard_fn,
-            convert_model_dtype=convert_model_dtype)
+            convert_model_dtype=convert_model_dtype,
+        )
 
         self.audio_encoder = AudioEncoder(
-            model_id=os.path.join(checkpoint_dir,
-                                  "wav2vec2-large-xlsr-53-english"))
+            model_id=os.path.join(checkpoint_dir, "wav2vec2-large-xlsr-53-english")
+        )
 
         if use_sp:
             self.sp_size = get_world_size()
@@ -143,8 +141,7 @@ class WanS2V:
         self.fps = config.sample_fps
         self.audio_sample_m = 0
 
-    def _configure_model(self, model, use_sp, dit_fsdp, shard_fn,
-                         convert_model_dtype):
+    def _configure_model(self, model, use_sp, dit_fsdp, shard_fn, convert_model_dtype):
         """
         Configures a model object. This includes setting evaluation modes,
         applying distributed parallel strategy, and handling device placement.
@@ -170,7 +167,8 @@ class WanS2V:
         if use_sp:
             for block in model.blocks:
                 block.self_attn.forward = types.MethodType(
-                    sp_attn_forward_s2v, block.self_attn)
+                    sp_attn_forward_s2v, block.self_attn
+                )
             model.use_context_parallel = True
 
         if dist.is_initialized():
@@ -186,11 +184,9 @@ class WanS2V:
 
         return model
 
-    def get_size_less_than_area(self,
-                                height,
-                                width,
-                                target_area=1024 * 704,
-                                divisor=64):
+    def get_size_less_than_area(
+        self, height, width, target_area=1024 * 704, divisor=64
+    ):
         if height * width <= target_area:
             # If the original image area is already less than or equal to the target,
             # no resizing is needed—just padding. Still need to ensure that the padded area doesn't exceed the target.
@@ -199,7 +195,9 @@ class WanS2V:
             max_scale = 1.0
         else:
             # Resize to fit within the target area and then pad to multiples of `divisor`
-            max_upper_area = target_area  # Maximum allowed total pixel count after padding
+            max_upper_area = (
+                target_area  # Maximum allowed total pixel count after padding
+            )
             d = divisor - 1
             b = d * (height + width)
             a = height * width
@@ -207,9 +205,11 @@ class WanS2V:
 
             # Calculate scale boundaries using quadratic equation
             min_scale = (-b + math.sqrt(b**2 - 2 * a * c)) / (
-                2 * a)  # Scale when maximum padding is applied
-            max_scale = math.sqrt(max_upper_area /
-                                  (height * width))  # Scale without any padding
+                2 * a
+            )  # Scale when maximum padding is applied
+            max_scale = math.sqrt(
+                max_upper_area / (height * width)
+            )  # Scale without any padding
 
         # We want to choose the largest possible scale such that the final padded area does not exceed max_upper_area
         # Use binary search-like iteration to find this scale
@@ -221,11 +221,6 @@ class WanS2V:
             # Pad to make dimensions divisible by 64
             pad_height = (64 - new_height % 64) % 64
             pad_width = (64 - new_width % 64) % 64
-            pad_top = pad_height // 2
-            pad_bottom = pad_height - pad_top
-            pad_left = pad_width // 2
-            pad_right = pad_width - pad_left
-
             padded_height, padded_width = new_height + pad_height, new_width + pad_width
 
             if padded_height * padded_width <= max_upper_area:
@@ -237,10 +232,10 @@ class WanS2V:
         else:
             # Fallback: calculate target dimensions based on aspect ratio and divisor alignment
             aspect_ratio = width / height
-            target_width = int(
-                (target_area * aspect_ratio)**0.5 // divisor * divisor)
+            target_width = int((target_area * aspect_ratio) ** 0.5 // divisor * divisor)
             target_height = int(
-                (target_area / aspect_ratio)**0.5 // divisor * divisor)
+                (target_area / aspect_ratio) ** 0.5 // divisor * divisor
+            )
 
             # Ensure the result is not larger than the original resolution
             if target_width >= width or target_height >= height:
@@ -249,29 +244,31 @@ class WanS2V:
 
             return target_height, target_width
 
-    def prepare_default_cond_input(self,
-                                   map_shape=[3, 12, 64, 64],
-                                   motion_frames=5,
-                                   lat_motion_frames=2,
-                                   enable_mano=False,
-                                   enable_kp=False,
-                                   enable_pose=False):
+    def prepare_default_cond_input(
+        self,
+        map_shape=[3, 12, 64, 64],
+        motion_frames=5,
+        lat_motion_frames=2,
+        enable_mano=False,
+        enable_kp=False,
+        enable_pose=False,
+    ):
         default_value = [1.0, -1.0, -1.0]
         cond_enable = [enable_mano, enable_kp, enable_pose]
         cond = []
         for d, c in zip(default_value, cond_enable):
             if c:
-                map_value = torch.ones(
-                    map_shape, dtype=self.param_dtype, device=self.device) * d
-                cond_lat = torch.cat([
-                    map_value[:, :, 0:1].repeat(1, 1, motion_frames, 1, 1),
-                    map_value
-                ],
-                                     dim=2)
-                cond_lat = torch.stack(
-                    self.vae.encode(cond_lat.to(
-                        self.param_dtype)))[:, :, lat_motion_frames:].to(
-                            self.param_dtype)
+                map_value = (
+                    torch.ones(map_shape, dtype=self.param_dtype, device=self.device)
+                    * d
+                )
+                cond_lat = torch.cat(
+                    [map_value[:, :, 0:1].repeat(1, 1, motion_frames, 1, 1), map_value],
+                    dim=2,
+                )
+                cond_lat = torch.stack(self.vae.encode(cond_lat.to(self.param_dtype)))[
+                    :, :, lat_motion_frames:
+                ].to(self.param_dtype)
 
                 cond.append(cond_lat)
         if len(cond) >= 1:
@@ -281,12 +278,11 @@ class WanS2V:
         return cond
 
     def encode_audio(self, audio_path, infer_frames):
-        z = self.audio_encoder.extract_audio_feat(
-            audio_path, return_all_layers=True)
+        z = self.audio_encoder.extract_audio_feat(audio_path, return_all_layers=True)
         audio_embed_bucket, num_repeat = self.audio_encoder.get_audio_embed_bucket_fps(
-            z, fps=self.fps, batch_frames=infer_frames, m=self.audio_sample_m)
-        audio_embed_bucket = audio_embed_bucket.to(self.device,
-                                                   self.param_dtype)
+            z, fps=self.fps, batch_frames=infer_frames, m=self.audio_sample_m
+        )
+        audio_embed_bucket = audio_embed_bucket.to(self.device, self.param_dtype)
         audio_embed_bucket = audio_embed_bucket.unsqueeze(0)
         if len(audio_embed_bucket.shape) == 3:
             audio_embed_bucket = audio_embed_bucket.permute(0, 2, 1)
@@ -294,11 +290,7 @@ class WanS2V:
             audio_embed_bucket = audio_embed_bucket.permute(0, 2, 3, 1)
         return audio_embed_bucket, num_repeat
 
-    def read_last_n_frames(self,
-                           video_path,
-                           n_frames,
-                           target_fps=16,
-                           reverse=False):
+    def read_last_n_frames(self, video_path, n_frames, target_fps=16, reverse=False):
         """
         Read the last `n_frames` from a video at the specified frame rate.
 
@@ -306,7 +298,7 @@ class WanS2V:
             video_path (str): Path to the video file.
             n_frames (int): Number of frames to read.
             target_fps (int, optional): Target sampling frame rate. Defaults to 16.
-            reverse (bool, optional): Whether to read frames in reverse order. 
+            reverse (bool, optional): Whether to read frames in reverse order.
                                     If True, reads the first `n_frames` instead of the last ones.
 
         Returns:
@@ -320,8 +312,7 @@ class WanS2V:
 
         required_span = (n_frames - 1) * interval
 
-        start_frame = max(0, total_frames - required_span -
-                          1) if not reverse else 0
+        start_frame = max(0, total_frames - required_span - 1) if not reverse else 0
 
         sampled_indices = []
         for i in range(n_frames):
@@ -335,28 +326,27 @@ class WanS2V:
 
     def load_pose_cond(self, pose_video, num_repeat, infer_frames, size):
         HEIGHT, WIDTH = size
-        if not pose_video is None:
+        if pose_video is not None:
             pose_seq = self.read_last_n_frames(
                 pose_video,
                 n_frames=infer_frames * num_repeat,
                 target_fps=self.fps,
-                reverse=True)
+                reverse=True,
+            )
 
             resize_opreat = transforms.Resize(min(HEIGHT, WIDTH))
             crop_opreat = transforms.CenterCrop((HEIGHT, WIDTH))
-            tensor_trans = transforms.ToTensor()
-
             cond_tensor = torch.from_numpy(pose_seq)
             cond_tensor = cond_tensor.permute(0, 3, 1, 2) / 255.0 * 2 - 1.0
-            cond_tensor = crop_opreat(resize_opreat(cond_tensor)).permute(
-                1, 0, 2, 3).unsqueeze(0)
+            cond_tensor = (
+                crop_opreat(resize_opreat(cond_tensor)).permute(1, 0, 2, 3).unsqueeze(0)
+            )
 
             padding_frame_num = num_repeat * infer_frames - cond_tensor.shape[2]
-            cond_tensor = torch.cat([
-                cond_tensor,
-                - torch.ones([1, 3, padding_frame_num, HEIGHT, WIDTH])
-            ],
-                                    dim=2)
+            cond_tensor = torch.cat(
+                [cond_tensor, -torch.ones([1, 3, padding_frame_num, HEIGHT, WIDTH])],
+                dim=2,
+            )
 
             cond_tensors = torch.chunk(cond_tensor, num_repeat, dim=2)
         else:
@@ -365,28 +355,27 @@ class WanS2V:
         COND = []
         for r in range(len(cond_tensors)):
             cond = cond_tensors[r]
-            cond = torch.cat([cond[:, :, 0:1].repeat(1, 1, 1, 1, 1), cond],
-                             dim=2)
+            cond = torch.cat([cond[:, :, 0:1].repeat(1, 1, 1, 1, 1), cond], dim=2)
             cond_lat = torch.stack(
-                self.vae.encode(
-                    cond.to(dtype=self.param_dtype,
-                            device=self.device)))[:, :,
-                                                  1:].cpu()  # for mem save
+                self.vae.encode(cond.to(dtype=self.param_dtype, device=self.device))
+            )[
+                :, :, 1:
+            ].cpu()  # for mem save
             COND.append(cond_lat)
         return COND
 
     def get_gen_size(self, size, max_area, ref_image_path, pre_video_path):
-        if not size is None:
+        if size is not None:
             HEIGHT, WIDTH = size
         else:
             if pre_video_path:
-                ref_image = self.read_last_n_frames(
-                    pre_video_path, n_frames=1)[0]
+                ref_image = self.read_last_n_frames(pre_video_path, n_frames=1)[0]
             else:
-                ref_image = np.array(Image.open(ref_image_path).convert('RGB'))
+                ref_image = np.array(Image.open(ref_image_path).convert("RGB"))
             HEIGHT, WIDTH = ref_image.shape[:2]
         HEIGHT, WIDTH = self.get_size_less_than_area(
-            HEIGHT, WIDTH, target_area=max_area)
+            HEIGHT, WIDTH, target_area=max_area
+        )
         return (HEIGHT, WIDTH)
 
     def generate(
@@ -399,7 +388,7 @@ class WanS2V:
         max_area=720 * 1280,
         infer_frames=80,
         shift=5.0,
-        sample_solver='unipc',
+        sample_solver="unipc",
         sampling_steps=40,
         guide_scale=5.0,
         n_prompt="",
@@ -458,7 +447,8 @@ class WanS2V:
             size=None,
             max_area=max_area,
             ref_image_path=ref_image_path,
-            pre_video_path=None)
+            pre_video_path=None,
+        )
         HEIGHT, WIDTH = size
         channel = 3
 
@@ -470,12 +460,13 @@ class WanS2V:
         motion_latents = None
 
         if ref_image is None:
-            ref_image = np.array(Image.open(ref_image_path).convert('RGB'))
+            ref_image = np.array(Image.open(ref_image_path).convert("RGB"))
         if motion_latents is None:
             motion_latents = torch.zeros(
                 [1, channel, self.motion_frames, HEIGHT, WIDTH],
                 dtype=self.param_dtype,
-                device=self.device)
+                device=self.device,
+            )
 
         # extract audio emb
         audio_emb, nr = self.encode_audio(audio_path, infer_frames=infer_frames)
@@ -486,10 +477,12 @@ class WanS2V:
         model_pic = crop_opreat(resize_opreat(Image.fromarray(ref_image)))
 
         ref_pixel_values = tensor_trans(model_pic)
-        ref_pixel_values = ref_pixel_values.unsqueeze(1).unsqueeze(
-            0) * 2 - 1.0  # b c 1 h w
+        ref_pixel_values = (
+            ref_pixel_values.unsqueeze(1).unsqueeze(0) * 2 - 1.0
+        )  # b c 1 h w
         ref_pixel_values = ref_pixel_values.to(
-            dtype=self.vae.dtype, device=self.vae.device)
+            dtype=self.vae.dtype, device=self.vae.device
+        )
         ref_latents = torch.stack(self.vae.encode(ref_pixel_values))
 
         # encode the motion latents
@@ -505,7 +498,8 @@ class WanS2V:
             pose_video=pose_video,
             num_repeat=num_repeat,
             infer_frames=infer_frames,
-            size=size)
+            size=size,
+        )
 
         seed = seed if seed >= 0 else random.randint(0, sys.maxsize)
 
@@ -513,30 +507,36 @@ class WanS2V:
             n_prompt = self.sample_neg_prompt
 
         # preprocess
-        if not self.t5_cpu:
+        # Honor CPU text-encoder when requested to save VRAM
+        if getattr(self, "t5_cpu", False):
+            try:
+                self.text_encoder.model.to("cpu")
+            except AttributeError:
+                pass
+            context = self.text_encoder([input_prompt], torch.device("cpu"))
+            context_null = self.text_encoder([n_prompt], torch.device("cpu"))
+            context = [t.to(self.device) for t in context]
+            context_null = [t.to(self.device) for t in context_null]
+        else:
             self.text_encoder.model.to(self.device)
             context = self.text_encoder([input_prompt], self.device)
             context_null = self.text_encoder([n_prompt], self.device)
             if offload_model:
                 self.text_encoder.model.cpu()
-        else:
-            context = self.text_encoder([input_prompt], torch.device('cpu'))
-            context_null = self.text_encoder([n_prompt], torch.device('cpu'))
-            context = [t.to(self.device) for t in context]
-            context_null = [t.to(self.device) for t in context_null]
 
         out = []
         # evaluation mode
         with (
-                torch.amp.autocast('cuda', dtype=self.param_dtype),
-                torch.no_grad(),
+            torch.amp.autocast("cuda", dtype=self.param_dtype),
+            torch.no_grad(),
         ):
             for r in range(num_repeat):
                 seed_g = torch.Generator(device=self.device)
                 seed_g.manual_seed(seed + r)
 
-                lat_target_frames = (infer_frames + 3 + self.motion_frames
-                                    ) // 4 - lat_motion_frames
+                lat_target_frames = (
+                    infer_frames + 3 + self.motion_frames
+                ) // 4 - lat_motion_frames
                 target_shape = [lat_target_frames, HEIGHT // 8, WIDTH // 8]
                 noise = [
                     torch.randn(
@@ -546,28 +546,31 @@ class WanS2V:
                         target_shape[2],
                         dtype=self.param_dtype,
                         device=self.device,
-                        generator=seed_g)
+                        generator=seed_g,
+                    )
                 ]
                 max_seq_len = np.prod(target_shape) // 4
 
-                if sample_solver == 'unipc':
+                if sample_solver == "unipc":
                     sample_scheduler = FlowUniPCMultistepScheduler(
                         num_train_timesteps=self.num_train_timesteps,
                         shift=1,
-                        use_dynamic_shifting=False)
+                        use_dynamic_shifting=False,
+                    )
                     sample_scheduler.set_timesteps(
-                        sampling_steps, device=self.device, shift=shift)
+                        sampling_steps, device=self.device, shift=shift
+                    )
                     timesteps = sample_scheduler.timesteps
-                elif sample_solver == 'dpm++':
+                elif sample_solver == "dpm++":
                     sample_scheduler = FlowDPMSolverMultistepScheduler(
                         num_train_timesteps=self.num_train_timesteps,
                         shift=1,
-                        use_dynamic_shifting=False)
+                        use_dynamic_shifting=False,
+                    )
                     sampling_sigmas = get_sampling_sigmas(sampling_steps, shift)
                     timesteps, _ = retrieve_timesteps(
-                        sample_scheduler,
-                        device=self.device,
-                        sigmas=sampling_sigmas)
+                        sample_scheduler, device=self.device, sigmas=sampling_sigmas
+                    )
                 else:
                     raise NotImplementedError("Unsupported solver.")
 
@@ -577,31 +580,30 @@ class WanS2V:
                     right_idx = r * infer_frames + infer_frames
                     cond_latents = COND[r] if pose_video else COND[0] * 0
                     cond_latents = cond_latents.to(
-                        dtype=self.param_dtype, device=self.device)
+                        dtype=self.param_dtype, device=self.device
+                    )
                     audio_input = audio_emb[..., left_idx:right_idx]
                 input_motion_latents = motion_latents.clone()
 
                 arg_c = {
-                    'context': context[0:1],
-                    'seq_len': max_seq_len,
-                    'cond_states': cond_latents,
+                    "context": context[0:1],
+                    "seq_len": max_seq_len,
+                    "cond_states": cond_latents,
                     "motion_latents": input_motion_latents,
-                    'ref_latents': ref_latents,
+                    "ref_latents": ref_latents,
                     "audio_input": audio_input,
                     "motion_frames": [self.motion_frames, lat_motion_frames],
                     "drop_motion_frames": drop_first_motion and r == 0,
                 }
                 if guide_scale > 1:
                     arg_null = {
-                        'context': context_null[0:1],
-                        'seq_len': max_seq_len,
-                        'cond_states': cond_latents,
+                        "context": context_null[0:1],
+                        "seq_len": max_seq_len,
+                        "cond_states": cond_latents,
                         "motion_latents": input_motion_latents,
-                        'ref_latents': ref_latents,
+                        "ref_latents": ref_latents,
                         "audio_input": 0.0 * audio_input,
-                        "motion_frames": [
-                            self.motion_frames, lat_motion_frames
-                        ],
+                        "motion_frames": [self.motion_frames, lat_motion_frames],
                         "drop_motion_frames": drop_first_motion and r == 0,
                     }
                 if offload_model or self.init_on_cpu:
@@ -615,11 +617,13 @@ class WanS2V:
                     timestep = torch.stack(timestep).to(self.device)
 
                     noise_pred_cond = self.noise_model(
-                        latent_model_input, t=timestep, **arg_c)
+                        latent_model_input, t=timestep, **arg_c
+                    )
 
                     if guide_scale > 1:
                         noise_pred_uncond = self.noise_model(
-                            latent_model_input, t=timestep, **arg_null)
+                            latent_model_input, t=timestep, **arg_null
+                        )
                         noise_pred = [
                             u + guide_scale * (c - u)
                             for c, u in zip(noise_pred_cond, noise_pred_uncond)
@@ -632,7 +636,8 @@ class WanS2V:
                         t,
                         latents[0].unsqueeze(0),
                         return_dict=False,
-                        generator=seed_g)[0]
+                        generator=seed_g,
+                    )[0]
                     latents[0] = temp_x0.squeeze(0)
 
                 if offload_model:
@@ -646,19 +651,21 @@ class WanS2V:
                     decode_latents = torch.cat([ref_latents, latents], dim=2)
                 image = torch.stack(self.vae.decode(decode_latents))
                 image = image[:, :, -(infer_frames):]
-                if (drop_first_motion and r == 0):
+                if drop_first_motion and r == 0:
                     image = image[:, :, 3:]
 
                 overlap_frames_num = min(self.motion_frames, image.shape[2])
-                videos_last_frames = torch.cat([
-                    videos_last_frames[:, :, overlap_frames_num:],
-                    image[:, :, -overlap_frames_num:]
-                ],
-                                               dim=2)
+                videos_last_frames = torch.cat(
+                    [
+                        videos_last_frames[:, :, overlap_frames_num:],
+                        image[:, :, -overlap_frames_num:],
+                    ],
+                    dim=2,
+                )
                 videos_last_frames = videos_last_frames.to(
-                    dtype=motion_latents.dtype, device=motion_latents.device)
-                motion_latents = torch.stack(
-                    self.vae.encode(videos_last_frames))
+                    dtype=motion_latents.dtype, device=motion_latents.device
+                )
+                motion_latents = torch.stack(self.vae.encode(videos_last_frames))
                 out.append(image.cpu())
 
         videos = torch.cat(out, dim=2)

--- a/inference/Wan2.2/wan/text2video.py
+++ b/inference/Wan2.2/wan/text2video.py
@@ -10,7 +10,6 @@ from contextlib import contextmanager
 from functools import partial
 
 import torch
-import torch.cuda.amp as amp
 import torch.distributed as dist
 from tqdm import tqdm
 
@@ -86,35 +85,41 @@ class WanT2V:
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,
-            device=torch.device('cpu'),
+            device=torch.device("cpu"),
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
-            shard_fn=shard_fn if t5_fsdp else None)
+            shard_fn=shard_fn if t5_fsdp else None,
+        )
 
         self.vae_stride = config.vae_stride
         self.patch_size = config.patch_size
         self.vae = Wan2_1_VAE(
             vae_pth=os.path.join(checkpoint_dir, config.vae_checkpoint),
-            device=self.device)
+            device=self.device,
+        )
 
         logging.info(f"Creating WanModel from {checkpoint_dir}")
         self.low_noise_model = WanModel.from_pretrained(
-            checkpoint_dir, subfolder=config.low_noise_checkpoint)
+            checkpoint_dir, subfolder=config.low_noise_checkpoint
+        )
         self.low_noise_model = self._configure_model(
             model=self.low_noise_model,
             use_sp=use_sp,
             dit_fsdp=dit_fsdp,
             shard_fn=shard_fn,
-            convert_model_dtype=convert_model_dtype)
+            convert_model_dtype=convert_model_dtype,
+        )
 
         self.high_noise_model = WanModel.from_pretrained(
-            checkpoint_dir, subfolder=config.high_noise_checkpoint)
+            checkpoint_dir, subfolder=config.high_noise_checkpoint
+        )
         self.high_noise_model = self._configure_model(
             model=self.high_noise_model,
             use_sp=use_sp,
             dit_fsdp=dit_fsdp,
             shard_fn=shard_fn,
-            convert_model_dtype=convert_model_dtype)
+            convert_model_dtype=convert_model_dtype,
+        )
         if use_sp:
             self.sp_size = get_world_size()
         else:
@@ -122,8 +127,7 @@ class WanT2V:
 
         self.sample_neg_prompt = config.sample_neg_prompt
 
-    def _configure_model(self, model, use_sp, dit_fsdp, shard_fn,
-                         convert_model_dtype):
+    def _configure_model(self, model, use_sp, dit_fsdp, shard_fn, convert_model_dtype):
         """
         Configures a model object. This includes setting evaluation modes,
         applying distributed parallel strategy, and handling device placement.
@@ -150,7 +154,8 @@ class WanT2V:
         if use_sp:
             for block in model.blocks:
                 block.self_attn.forward = types.MethodType(
-                    sp_attn_forward, block.self_attn)
+                    sp_attn_forward, block.self_attn
+                )
             model.forward = types.MethodType(sp_dit_forward, model)
 
         if dist.is_initialized():
@@ -184,33 +189,37 @@ class WanT2V:
                 The active model on the target device for the current timestep.
         """
         if t.item() >= boundary:
-            required_model_name = 'high_noise_model'
-            offload_model_name = 'low_noise_model'
+            required_model_name = "high_noise_model"
+            offload_model_name = "low_noise_model"
         else:
-            required_model_name = 'low_noise_model'
-            offload_model_name = 'high_noise_model'
+            required_model_name = "low_noise_model"
+            offload_model_name = "high_noise_model"
         if offload_model or self.init_on_cpu:
-            if next(getattr(
-                    self,
-                    offload_model_name).parameters()).device.type == 'cuda':
-                getattr(self, offload_model_name).to('cpu')
-            if next(getattr(
-                    self,
-                    required_model_name).parameters()).device.type == 'cpu':
+            if (
+                next(getattr(self, offload_model_name).parameters()).device.type
+                == "cuda"
+            ):
+                getattr(self, offload_model_name).to("cpu")
+            if (
+                next(getattr(self, required_model_name).parameters()).device.type
+                == "cpu"
+            ):
                 getattr(self, required_model_name).to(self.device)
         return getattr(self, required_model_name)
 
-    def generate(self,
-                 input_prompt,
-                 size=(1280, 720),
-                 frame_num=81,
-                 shift=5.0,
-                 sample_solver='unipc',
-                 sampling_steps=50,
-                 guide_scale=5.0,
-                 n_prompt="",
-                 seed=-1,
-                 offload_model=True):
+    def generate(
+        self,
+        input_prompt,
+        size=(1280, 720),
+        frame_num=81,
+        shift=5.0,
+        sample_solver="unipc",
+        sampling_steps=50,
+        guide_scale=5.0,
+        n_prompt="",
+        seed=-1,
+        offload_model=True,
+    ):
         r"""
         Generates video frames from text prompt using diffusion process.
 
@@ -247,16 +256,28 @@ class WanT2V:
                 - W: Frame width from size)
         """
         # preprocess
-        guide_scale = (guide_scale, guide_scale) if isinstance(
-            guide_scale, float) else guide_scale
+        guide_scale = (
+            (guide_scale, guide_scale)
+            if isinstance(guide_scale, float)
+            else guide_scale
+        )
         F = frame_num
-        target_shape = (self.vae.model.z_dim, (F - 1) // self.vae_stride[0] + 1,
-                        size[1] // self.vae_stride[1],
-                        size[0] // self.vae_stride[2])
+        target_shape = (
+            self.vae.model.z_dim,
+            (F - 1) // self.vae_stride[0] + 1,
+            size[1] // self.vae_stride[1],
+            size[0] // self.vae_stride[2],
+        )
 
-        seq_len = math.ceil((target_shape[2] * target_shape[3]) /
-                            (self.patch_size[1] * self.patch_size[2]) *
-                            target_shape[1] / self.sp_size) * self.sp_size
+        seq_len = (
+            math.ceil(
+                (target_shape[2] * target_shape[3])
+                / (self.patch_size[1] * self.patch_size[2])
+                * target_shape[1]
+                / self.sp_size
+            )
+            * self.sp_size
+        )
 
         if n_prompt == "":
             n_prompt = self.sample_neg_prompt
@@ -264,17 +285,22 @@ class WanT2V:
         seed_g = torch.Generator(device=self.device)
         seed_g.manual_seed(seed)
 
-        if not self.t5_cpu:
+        # Honor CPU text-encoder when requested to save VRAM
+        if getattr(self, "t5_cpu", False):
+            try:
+                self.text_encoder.model.to("cpu")
+            except AttributeError:
+                pass
+            context = self.text_encoder([input_prompt], torch.device("cpu"))
+            context_null = self.text_encoder([n_prompt], torch.device("cpu"))
+            context = [t.to(self.device) for t in context]
+            context_null = [t.to(self.device) for t in context_null]
+        else:
             self.text_encoder.model.to(self.device)
             context = self.text_encoder([input_prompt], self.device)
             context_null = self.text_encoder([n_prompt], self.device)
             if offload_model:
                 self.text_encoder.model.cpu()
-        else:
-            context = self.text_encoder([input_prompt], torch.device('cpu'))
-            context_null = self.text_encoder([n_prompt], torch.device('cpu'))
-            context = [t.to(self.device) for t in context]
-            context_null = [t.to(self.device) for t in context_null]
 
         noise = [
             torch.randn(
@@ -284,53 +310,54 @@ class WanT2V:
                 target_shape[3],
                 dtype=torch.float32,
                 device=self.device,
-                generator=seed_g)
+                generator=seed_g,
+            )
         ]
 
         @contextmanager
         def noop_no_sync():
             yield
 
-        no_sync_low_noise = getattr(self.low_noise_model, 'no_sync',
-                                    noop_no_sync)
-        no_sync_high_noise = getattr(self.high_noise_model, 'no_sync',
-                                     noop_no_sync)
+        no_sync_low_noise = getattr(self.low_noise_model, "no_sync", noop_no_sync)
+        no_sync_high_noise = getattr(self.high_noise_model, "no_sync", noop_no_sync)
 
         # evaluation mode
         with (
-                torch.amp.autocast('cuda', dtype=self.param_dtype),
-                torch.no_grad(),
-                no_sync_low_noise(),
-                no_sync_high_noise(),
+            torch.amp.autocast("cuda", dtype=self.param_dtype),
+            torch.no_grad(),
+            no_sync_low_noise(),
+            no_sync_high_noise(),
         ):
             boundary = self.boundary * self.num_train_timesteps
 
-            if sample_solver == 'unipc':
+            if sample_solver == "unipc":
                 sample_scheduler = FlowUniPCMultistepScheduler(
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
-                    use_dynamic_shifting=False)
+                    use_dynamic_shifting=False,
+                )
                 sample_scheduler.set_timesteps(
-                    sampling_steps, device=self.device, shift=shift)
+                    sampling_steps, device=self.device, shift=shift
+                )
                 timesteps = sample_scheduler.timesteps
-            elif sample_solver == 'dpm++':
+            elif sample_solver == "dpm++":
                 sample_scheduler = FlowDPMSolverMultistepScheduler(
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
-                    use_dynamic_shifting=False)
+                    use_dynamic_shifting=False,
+                )
                 sampling_sigmas = get_sampling_sigmas(sampling_steps, shift)
                 timesteps, _ = retrieve_timesteps(
-                    sample_scheduler,
-                    device=self.device,
-                    sigmas=sampling_sigmas)
+                    sample_scheduler, device=self.device, sigmas=sampling_sigmas
+                )
             else:
                 raise NotImplementedError("Unsupported solver.")
 
             # sample videos
             latents = noise
 
-            arg_c = {'context': context, 'seq_len': seq_len}
-            arg_null = {'context': context_null, 'seq_len': seq_len}
+            arg_c = {"context": context, "seq_len": seq_len}
+            arg_null = {"context": context_null, "seq_len": seq_len}
 
             for _, t in enumerate(tqdm(timesteps)):
                 latent_model_input = latents
@@ -338,25 +365,25 @@ class WanT2V:
 
                 timestep = torch.stack(timestep)
 
-                model = self._prepare_model_for_timestep(
-                    t, boundary, offload_model)
-                sample_guide_scale = guide_scale[1] if t.item(
-                ) >= boundary else guide_scale[0]
+                model = self._prepare_model_for_timestep(t, boundary, offload_model)
+                sample_guide_scale = (
+                    guide_scale[1] if t.item() >= boundary else guide_scale[0]
+                )
 
-                noise_pred_cond = model(
-                    latent_model_input, t=timestep, **arg_c)[0]
-                noise_pred_uncond = model(
-                    latent_model_input, t=timestep, **arg_null)[0]
+                noise_pred_cond = model(latent_model_input, t=timestep, **arg_c)[0]
+                noise_pred_uncond = model(latent_model_input, t=timestep, **arg_null)[0]
 
                 noise_pred = noise_pred_uncond + sample_guide_scale * (
-                    noise_pred_cond - noise_pred_uncond)
+                    noise_pred_cond - noise_pred_uncond
+                )
 
                 temp_x0 = sample_scheduler.step(
                     noise_pred.unsqueeze(0),
                     t,
                     latents[0].unsqueeze(0),
                     return_dict=False,
-                    generator=seed_g)[0]
+                    generator=seed_g,
+                )[0]
                 latents = [temp_x0.squeeze(0)]
 
             x0 = latents

--- a/inference/Wan2.2/wan/textimage2video.py
+++ b/inference/Wan2.2/wan/textimage2video.py
@@ -10,7 +10,6 @@ from contextlib import contextmanager
 from functools import partial
 
 import torch
-import torch.cuda.amp as amp
 import torch.distributed as dist
 import torchvision.transforms.functional as TF
 from PIL import Image
@@ -88,16 +87,18 @@ class WanTI2V:
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,
-            device=torch.device('cpu'),
+            device=torch.device("cpu"),
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
-            shard_fn=shard_fn if t5_fsdp else None)
+            shard_fn=shard_fn if t5_fsdp else None,
+        )
 
         self.vae_stride = config.vae_stride
         self.patch_size = config.patch_size
         self.vae = Wan2_2_VAE(
             vae_pth=os.path.join(checkpoint_dir, config.vae_checkpoint),
-            device=self.device)
+            device=self.device,
+        )
 
         logging.info(f"Creating WanModel from {checkpoint_dir}")
         self.model = WanModel.from_pretrained(checkpoint_dir)
@@ -106,7 +107,8 @@ class WanTI2V:
             use_sp=use_sp,
             dit_fsdp=dit_fsdp,
             shard_fn=shard_fn,
-            convert_model_dtype=convert_model_dtype)
+            convert_model_dtype=convert_model_dtype,
+        )
 
         if use_sp:
             self.sp_size = get_world_size()
@@ -115,8 +117,7 @@ class WanTI2V:
 
         self.sample_neg_prompt = config.sample_neg_prompt
 
-    def _configure_model(self, model, use_sp, dit_fsdp, shard_fn,
-                         convert_model_dtype):
+    def _configure_model(self, model, use_sp, dit_fsdp, shard_fn, convert_model_dtype):
         """
         Configures a model object. This includes setting evaluation modes,
         applying distributed parallel strategy, and handling device placement.
@@ -143,7 +144,8 @@ class WanTI2V:
         if use_sp:
             for block in model.blocks:
                 block.self_attn.forward = types.MethodType(
-                    sp_attn_forward, block.self_attn)
+                    sp_attn_forward, block.self_attn
+                )
             model.forward = types.MethodType(sp_dit_forward, model)
 
         if dist.is_initialized():
@@ -159,19 +161,21 @@ class WanTI2V:
 
         return model
 
-    def generate(self,
-                 input_prompt,
-                 img=None,
-                 size=(1280, 704),
-                 max_area=704 * 1280,
-                 frame_num=81,
-                 shift=5.0,
-                 sample_solver='unipc',
-                 sampling_steps=50,
-                 guide_scale=5.0,
-                 n_prompt="",
-                 seed=-1,
-                 offload_model=True):
+    def generate(
+        self,
+        input_prompt,
+        img=None,
+        size=(1280, 704),
+        max_area=704 * 1280,
+        frame_num=81,
+        shift=5.0,
+        sample_solver="unipc",
+        sampling_steps=50,
+        guide_scale=5.0,
+        n_prompt="",
+        seed=-1,
+        offload_model=True,
+    ):
         r"""
         Generates video frames from text prompt using diffusion process.
 
@@ -222,7 +226,8 @@ class WanTI2V:
                 guide_scale=guide_scale,
                 n_prompt=n_prompt,
                 seed=seed,
-                offload_model=offload_model)
+                offload_model=offload_model,
+            )
         # t2v
         return self.t2v(
             input_prompt=input_prompt,
@@ -234,19 +239,22 @@ class WanTI2V:
             guide_scale=guide_scale,
             n_prompt=n_prompt,
             seed=seed,
-            offload_model=offload_model)
+            offload_model=offload_model,
+        )
 
-    def t2v(self,
-            input_prompt,
-            size=(1280, 704),
-            frame_num=121,
-            shift=5.0,
-            sample_solver='unipc',
-            sampling_steps=50,
-            guide_scale=5.0,
-            n_prompt="",
-            seed=-1,
-            offload_model=True):
+    def t2v(
+        self,
+        input_prompt,
+        size=(1280, 704),
+        frame_num=121,
+        shift=5.0,
+        sample_solver="unipc",
+        sampling_steps=50,
+        guide_scale=5.0,
+        n_prompt="",
+        seed=-1,
+        offload_model=True,
+    ):
         r"""
         Generates video frames from text prompt using diffusion process.
 
@@ -282,13 +290,22 @@ class WanTI2V:
         """
         # preprocess
         F = frame_num
-        target_shape = (self.vae.model.z_dim, (F - 1) // self.vae_stride[0] + 1,
-                        size[1] // self.vae_stride[1],
-                        size[0] // self.vae_stride[2])
+        target_shape = (
+            self.vae.model.z_dim,
+            (F - 1) // self.vae_stride[0] + 1,
+            size[1] // self.vae_stride[1],
+            size[0] // self.vae_stride[2],
+        )
 
-        seq_len = math.ceil((target_shape[2] * target_shape[3]) /
-                            (self.patch_size[1] * self.patch_size[2]) *
-                            target_shape[1] / self.sp_size) * self.sp_size
+        seq_len = (
+            math.ceil(
+                (target_shape[2] * target_shape[3])
+                / (self.patch_size[1] * self.patch_size[2])
+                * target_shape[1]
+                / self.sp_size
+            )
+            * self.sp_size
+        )
 
         if n_prompt == "":
             n_prompt = self.sample_neg_prompt
@@ -296,17 +313,22 @@ class WanTI2V:
         seed_g = torch.Generator(device=self.device)
         seed_g.manual_seed(seed)
 
-        if not self.t5_cpu:
+        # Honor CPU text-encoder when requested to save VRAM
+        if getattr(self, "t5_cpu", False):
+            try:
+                self.text_encoder.model.to("cpu")
+            except AttributeError:
+                pass
+            context = self.text_encoder([input_prompt], torch.device("cpu"))
+            context_null = self.text_encoder([n_prompt], torch.device("cpu"))
+            context = [t.to(self.device) for t in context]
+            context_null = [t.to(self.device) for t in context_null]
+        else:
             self.text_encoder.model.to(self.device)
             context = self.text_encoder([input_prompt], self.device)
             context_null = self.text_encoder([n_prompt], self.device)
             if offload_model:
                 self.text_encoder.model.cpu()
-        else:
-            context = self.text_encoder([input_prompt], torch.device('cpu'))
-            context_null = self.text_encoder([n_prompt], torch.device('cpu'))
-            context = [t.to(self.device) for t in context]
-            context_null = [t.to(self.device) for t in context_null]
 
         noise = [
             torch.randn(
@@ -316,40 +338,43 @@ class WanTI2V:
                 target_shape[3],
                 dtype=torch.float32,
                 device=self.device,
-                generator=seed_g)
+                generator=seed_g,
+            )
         ]
 
         @contextmanager
         def noop_no_sync():
             yield
 
-        no_sync = getattr(self.model, 'no_sync', noop_no_sync)
+        no_sync = getattr(self.model, "no_sync", noop_no_sync)
 
         # evaluation mode
         with (
-                torch.amp.autocast('cuda', dtype=self.param_dtype),
-                torch.no_grad(),
-                no_sync(),
+            torch.amp.autocast("cuda", dtype=self.param_dtype),
+            torch.no_grad(),
+            no_sync(),
         ):
 
-            if sample_solver == 'unipc':
+            if sample_solver == "unipc":
                 sample_scheduler = FlowUniPCMultistepScheduler(
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
-                    use_dynamic_shifting=False)
+                    use_dynamic_shifting=False,
+                )
                 sample_scheduler.set_timesteps(
-                    sampling_steps, device=self.device, shift=shift)
+                    sampling_steps, device=self.device, shift=shift
+                )
                 timesteps = sample_scheduler.timesteps
-            elif sample_solver == 'dpm++':
+            elif sample_solver == "dpm++":
                 sample_scheduler = FlowDPMSolverMultistepScheduler(
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
-                    use_dynamic_shifting=False)
+                    use_dynamic_shifting=False,
+                )
                 sampling_sigmas = get_sampling_sigmas(sampling_steps, shift)
                 timesteps, _ = retrieve_timesteps(
-                    sample_scheduler,
-                    device=self.device,
-                    sigmas=sampling_sigmas)
+                    sample_scheduler, device=self.device, sigmas=sampling_sigmas
+                )
             else:
                 raise NotImplementedError("Unsupported solver.")
 
@@ -357,8 +382,8 @@ class WanTI2V:
             latents = noise
             mask1, mask2 = masks_like(noise, zero=False)
 
-            arg_c = {'context': context, 'seq_len': seq_len}
-            arg_null = {'context': context_null, 'seq_len': seq_len}
+            arg_c = {"context": context, "seq_len": seq_len}
+            arg_null = {"context": context_null, "seq_len": seq_len}
 
             if offload_model or self.init_on_cpu:
                 self.model.to(self.device)
@@ -371,26 +396,27 @@ class WanTI2V:
                 timestep = torch.stack(timestep)
 
                 temp_ts = (mask2[0][0][:, ::2, ::2] * timestep).flatten()
-                temp_ts = torch.cat([
-                    temp_ts,
-                    temp_ts.new_ones(seq_len - temp_ts.size(0)) * timestep
-                ])
+                temp_ts = torch.cat(
+                    [temp_ts, temp_ts.new_ones(seq_len - temp_ts.size(0)) * timestep]
+                )
                 timestep = temp_ts.unsqueeze(0)
 
-                noise_pred_cond = self.model(
-                    latent_model_input, t=timestep, **arg_c)[0]
+                noise_pred_cond = self.model(latent_model_input, t=timestep, **arg_c)[0]
                 noise_pred_uncond = self.model(
-                    latent_model_input, t=timestep, **arg_null)[0]
+                    latent_model_input, t=timestep, **arg_null
+                )[0]
 
                 noise_pred = noise_pred_uncond + guide_scale * (
-                    noise_pred_cond - noise_pred_uncond)
+                    noise_pred_cond - noise_pred_uncond
+                )
 
                 temp_x0 = sample_scheduler.step(
                     noise_pred.unsqueeze(0),
                     t,
                     latents[0].unsqueeze(0),
                     return_dict=False,
-                    generator=seed_g)[0]
+                    generator=seed_g,
+                )[0]
                 latents = [temp_x0.squeeze(0)]
             x0 = latents
             if offload_model:
@@ -410,18 +436,20 @@ class WanTI2V:
 
         return videos[0] if self.rank == 0 else None
 
-    def i2v(self,
-            input_prompt,
-            img,
-            max_area=704 * 1280,
-            frame_num=121,
-            shift=5.0,
-            sample_solver='unipc',
-            sampling_steps=40,
-            guide_scale=5.0,
-            n_prompt="",
-            seed=-1,
-            offload_model=True):
+    def i2v(
+        self,
+        input_prompt,
+        img,
+        max_area=704 * 1280,
+        frame_num=121,
+        shift=5.0,
+        sample_solver="unipc",
+        sampling_steps=40,
+        guide_scale=5.0,
+        n_prompt="",
+        seed=-1,
+        offload_model=True,
+    ):
         r"""
         Generates video frames from input image and text prompt using diffusion process.
 
@@ -460,8 +488,10 @@ class WanTI2V:
         """
         # preprocess
         ih, iw = img.height, img.width
-        dh, dw = self.patch_size[1] * self.vae_stride[1], self.patch_size[
-            2] * self.vae_stride[2]
+        dh, dw = (
+            self.patch_size[1] * self.vae_stride[1],
+            self.patch_size[2] * self.vae_stride[2],
+        )
         ow, oh = best_output_size(iw, ih, dw, dh, max_area)
 
         scale = max(ow / iw, oh / ih)
@@ -477,37 +507,47 @@ class WanTI2V:
         img = TF.to_tensor(img).sub_(0.5).div_(0.5).to(self.device).unsqueeze(1)
 
         F = frame_num
-        seq_len = ((F - 1) // self.vae_stride[0] + 1) * (
-            oh // self.vae_stride[1]) * (ow // self.vae_stride[2]) // (
-                self.patch_size[1] * self.patch_size[2])
+        seq_len = (
+            ((F - 1) // self.vae_stride[0] + 1)
+            * (oh // self.vae_stride[1])
+            * (ow // self.vae_stride[2])
+            // (self.patch_size[1] * self.patch_size[2])
+        )
         seq_len = int(math.ceil(seq_len / self.sp_size)) * self.sp_size
 
         seed = seed if seed >= 0 else random.randint(0, sys.maxsize)
         seed_g = torch.Generator(device=self.device)
         seed_g.manual_seed(seed)
         noise = torch.randn(
-            self.vae.model.z_dim, (F - 1) // self.vae_stride[0] + 1,
+            self.vae.model.z_dim,
+            (F - 1) // self.vae_stride[0] + 1,
             oh // self.vae_stride[1],
             ow // self.vae_stride[2],
             dtype=torch.float32,
             generator=seed_g,
-            device=self.device)
+            device=self.device,
+        )
 
         if n_prompt == "":
             n_prompt = self.sample_neg_prompt
 
         # preprocess
-        if not self.t5_cpu:
+        # Honor CPU text-encoder when requested to save VRAM
+        if getattr(self, "t5_cpu", False):
+            try:
+                self.text_encoder.model.to("cpu")
+            except AttributeError:
+                pass
+            context = self.text_encoder([input_prompt], torch.device("cpu"))
+            context_null = self.text_encoder([n_prompt], torch.device("cpu"))
+            context = [t.to(self.device) for t in context]
+            context_null = [t.to(self.device) for t in context_null]
+        else:
             self.text_encoder.model.to(self.device)
             context = self.text_encoder([input_prompt], self.device)
             context_null = self.text_encoder([n_prompt], self.device)
             if offload_model:
                 self.text_encoder.model.cpu()
-        else:
-            context = self.text_encoder([input_prompt], torch.device('cpu'))
-            context_null = self.text_encoder([n_prompt], torch.device('cpu'))
-            context = [t.to(self.device) for t in context]
-            context_null = [t.to(self.device) for t in context_null]
 
         z = self.vae.encode([img])
 
@@ -515,49 +555,51 @@ class WanTI2V:
         def noop_no_sync():
             yield
 
-        no_sync = getattr(self.model, 'no_sync', noop_no_sync)
+        no_sync = getattr(self.model, "no_sync", noop_no_sync)
 
         # evaluation mode
         with (
-                torch.amp.autocast('cuda', dtype=self.param_dtype),
-                torch.no_grad(),
-                no_sync(),
+            torch.amp.autocast("cuda", dtype=self.param_dtype),
+            torch.no_grad(),
+            no_sync(),
         ):
 
-            if sample_solver == 'unipc':
+            if sample_solver == "unipc":
                 sample_scheduler = FlowUniPCMultistepScheduler(
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
-                    use_dynamic_shifting=False)
+                    use_dynamic_shifting=False,
+                )
                 sample_scheduler.set_timesteps(
-                    sampling_steps, device=self.device, shift=shift)
+                    sampling_steps, device=self.device, shift=shift
+                )
                 timesteps = sample_scheduler.timesteps
-            elif sample_solver == 'dpm++':
+            elif sample_solver == "dpm++":
                 sample_scheduler = FlowDPMSolverMultistepScheduler(
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
-                    use_dynamic_shifting=False)
+                    use_dynamic_shifting=False,
+                )
                 sampling_sigmas = get_sampling_sigmas(sampling_steps, shift)
                 timesteps, _ = retrieve_timesteps(
-                    sample_scheduler,
-                    device=self.device,
-                    sigmas=sampling_sigmas)
+                    sample_scheduler, device=self.device, sigmas=sampling_sigmas
+                )
             else:
                 raise NotImplementedError("Unsupported solver.")
 
             # sample videos
             latent = noise
             mask1, mask2 = masks_like([noise], zero=True)
-            latent = (1. - mask2[0]) * z[0] + mask2[0] * latent
+            latent = (1.0 - mask2[0]) * z[0] + mask2[0] * latent
 
             arg_c = {
-                'context': [context[0]],
-                'seq_len': seq_len,
+                "context": [context[0]],
+                "seq_len": seq_len,
             }
 
             arg_null = {
-                'context': context_null,
-                'seq_len': seq_len,
+                "context": context_null,
+                "seq_len": seq_len,
             }
 
             if offload_model or self.init_on_cpu:
@@ -571,31 +613,32 @@ class WanTI2V:
                 timestep = torch.stack(timestep).to(self.device)
 
                 temp_ts = (mask2[0][0][:, ::2, ::2] * timestep).flatten()
-                temp_ts = torch.cat([
-                    temp_ts,
-                    temp_ts.new_ones(seq_len - temp_ts.size(0)) * timestep
-                ])
+                temp_ts = torch.cat(
+                    [temp_ts, temp_ts.new_ones(seq_len - temp_ts.size(0)) * timestep]
+                )
                 timestep = temp_ts.unsqueeze(0)
 
-                noise_pred_cond = self.model(
-                    latent_model_input, t=timestep, **arg_c)[0]
+                noise_pred_cond = self.model(latent_model_input, t=timestep, **arg_c)[0]
                 if offload_model:
                     torch.cuda.empty_cache()
                 noise_pred_uncond = self.model(
-                    latent_model_input, t=timestep, **arg_null)[0]
+                    latent_model_input, t=timestep, **arg_null
+                )[0]
                 if offload_model:
                     torch.cuda.empty_cache()
                 noise_pred = noise_pred_uncond + guide_scale * (
-                    noise_pred_cond - noise_pred_uncond)
+                    noise_pred_cond - noise_pred_uncond
+                )
 
                 temp_x0 = sample_scheduler.step(
                     noise_pred.unsqueeze(0),
                     t,
                     latent.unsqueeze(0),
                     return_dict=False,
-                    generator=seed_g)[0]
+                    generator=seed_g,
+                )[0]
                 latent = temp_x0.squeeze(0)
-                latent = (1. - mask2[0]) * z[0] + mask2[0] * latent
+                latent = (1.0 - mask2[0]) * z[0] + mask2[0] * latent
 
                 x0 = [latent]
                 del latent_model_input, timestep

--- a/train_kv_lora_distill.py
+++ b/train_kv_lora_distill.py
@@ -23,6 +23,7 @@ from datetime import datetime, timezone
 import shutil
 from tqdm import tqdm
 import time
+import gc
 
 import torch
 from torch.optim import AdamW
@@ -253,6 +254,55 @@ def _parse_step_from_filename(path: str) -> int:
     return int(m.group(1)) if m else 0
 
 
+def _release_training_gpu(objs: list[object]):
+    for o in objs:
+        try:
+            getattr(o, "to", lambda *_args, **_kw: None)("cpu")
+        except Exception:
+            pass
+    del objs[:]
+    torch.cuda.empty_cache()
+    gc.collect()
+
+
+def _rebuild_training(cfg, args):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    from wan.modules.model import WanModel
+
+    model = WanModel(**cfg).to(device)
+    filtered = _load_filtered_state(
+        getattr(args, "transformer_weights_dir", None),
+        getattr(args, "transformer_weights", None),
+    )
+    model.load_state_dict(filtered, strict=False)
+    model.requires_grad_(False)
+    _ = inject_lora_kv(model, rank=args.rank, alpha=args.alpha)
+    from glob import glob
+
+    latest = sorted(glob(os.path.join(args.out_dir, "adapter_step_*.safetensors")))[-1]
+    load_peft_adapter(model, path=latest, prefix=args.adapter_prefix, alpha=args.alpha)
+    params = lora_parameters(model)
+    optim = AdamW(params, lr=args.lr, weight_decay=0.0)
+    opt_latest = sorted(glob(os.path.join(args.out_dir, "optimizer_step_*.pt")))[-1]
+    state = torch.load(opt_latest, map_location="cpu")
+    optim.load_state_dict(state.get("state_dict", state))
+    enc_device = torch.device("cpu")
+    enc_dtype = torch.float32
+    teacher_enc = T5EncoderModel(
+        text_len=getattr(model, "text_len", 512),
+        checkpoint_path=args.t5_checkpoint,
+        tokenizer_path=args.t5_tokenizer_dir or args.t5_tokenizer,
+        device=enc_device,
+        dtype=enc_dtype,
+    )
+    bridge_enc = BridgeEncoderModel(
+        text_len=getattr(model, "text_len", 512),
+        device=enc_device,
+        dtype=enc_dtype,
+    )
+    return model, teacher_enc, bridge_enc, optim
+
+
 # -----------------------------------------------------------------------------
 # Main training routine
 # -----------------------------------------------------------------------------
@@ -260,6 +310,14 @@ def _parse_step_from_filename(path: str) -> int:
 
 def train(args: argparse.Namespace) -> None:
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    enc_device = torch.device(
+        args.enc_device
+        if args.enc_device == "cpu" or torch.cuda.is_available()
+        else "cpu"
+    )
+    enc_dtype = (
+        torch.bfloat16 if (args.bf16 and enc_device.type == "cuda") else torch.float32
+    )
 
     # --- load Wan model ---------------------------------------------------
     # reports dir (AGENTS.md policy)
@@ -357,12 +415,14 @@ def train(args: argparse.Namespace) -> None:
         env["WAN_BRIDGE_CKPT"] = args.bridge_ckpt
         env["WAN_BRIDGE_LLM_DIR"] = args.llm_dir
         env["WAN_BRIDGE_GLOBAL_SCALE"] = str(args.global_scale)
+        env["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
         gen = os.path.join(Path(__file__).parent, "inference", "Wan2.2", "generate.py")
         base = (
             f'python "{gen}" --task {args.sample_task} '
             f'--ckpt_dir "{args.transformer_weights_dir or os.path.dirname(args.transformer_weights)}" '
             f"--size {args.sample_size} --frame_num {args.sample_frame_num} "
             f"--sample_steps {args.sample_steps} --sample_guide_scale {args.sample_guide_scale} "
+            f"--t5_cpu --offload_model True "
             f"--base_seed {args.sample_seed}"
         )
         try:
@@ -382,8 +442,8 @@ def train(args: argparse.Namespace) -> None:
         text_len=text_len,
         checkpoint_path=args.t5_checkpoint,
         tokenizer_path=args.t5_tokenizer_dir or args.t5_tokenizer,
-        device=device,
-        dtype=torch.bfloat16 if args.bf16 else torch.float32,
+        device=enc_device,
+        dtype=enc_dtype,
     )
 
     # bridge env variables
@@ -392,9 +452,10 @@ def train(args: argparse.Namespace) -> None:
     os.environ["WAN_BRIDGE_GLOBAL_SCALE"] = str(args.global_scale)
     bridge_enc = BridgeEncoderModel(
         text_len=text_len,
-        device=device,
-        dtype=torch.bfloat16 if args.bf16 else torch.float32,
+        device=enc_device,
+        dtype=enc_dtype,
     )
+    print(f"[enc] teacher on {enc_device}, bridge on {enc_device}")
 
     dataset = PromptDataset(
         args.prompts_file,
@@ -414,6 +475,7 @@ def train(args: argparse.Namespace) -> None:
 
     params = lora_parameters(model)
     optim = AdamW(params, lr=args.lr, weight_decay=0.0)
+    optim.zero_grad(set_to_none=True)
     # Optionally resume optimizer
     if args.resume_optimizer and os.path.exists(args.resume_optimizer):
         state = torch.load(args.resume_optimizer, map_location="cpu")
@@ -441,16 +503,20 @@ def train(args: argparse.Namespace) -> None:
             set_lora_enabled(model, False)
             with torch.no_grad():
                 teacher_tokens, mask = encode_teacher(
-                    batch_prompts, teacher_enc, device, text_len
+                    batch_prompts, teacher_enc, enc_device, text_len
                 )
+                teacher_tokens = teacher_tokens.to(device)
+                mask = mask.to(device)
                 teacher_context = model.text_embedding(teacher_tokens.float())
                 k_t, v_t = compute_kv(model, teacher_context, args.use_normed_targets)
 
             # student pass (LoRA enabled)
             set_lora_enabled(model, True)
             bridge_tokens, mask_bridge = encode_bridge(
-                batch_prompts, bridge_enc, device, text_len
+                batch_prompts, bridge_enc, enc_device, text_len
             )
+            bridge_tokens = bridge_tokens.to(device)
+            mask_bridge = mask_bridge.to(device)
             bridge_context = model.text_embedding(bridge_tokens.float())
             k_s, v_s = compute_kv(model, bridge_context, args.use_normed_targets)
 
@@ -464,12 +530,16 @@ def train(args: argparse.Namespace) -> None:
                 mse_v = ((vs - vt) ** 2) * mask_inter
                 loss = loss + mse_k.sum() / denom + mse_v.sum() / denom
 
-            optim.zero_grad()
+            loss_raw = loss
+            loss = loss / args.grad_accum
             loss.backward()
-            torch.nn.utils.clip_grad_norm_(params, 1.0)
-            optim.step()
+            if ((steps_total + 1) % args.grad_accum) == 0:
+                torch.nn.utils.clip_grad_norm_(params, 1.0)
+                optim.step()
+                optim.zero_grad(set_to_none=True)
             # progress
-            loss_val = float(loss.detach().item())
+            loss_val = float(loss_raw.detach().item())
+            loss = loss_raw
             ema = (
                 (ema_beta * ema + (1 - ema_beta) * loss_val)
                 if ema is not None
@@ -533,6 +603,7 @@ def train(args: argparse.Namespace) -> None:
                         env["WAN_BRIDGE_CKPT"] = args.bridge_ckpt
                         env["WAN_BRIDGE_LLM_DIR"] = args.llm_dir
                         env["WAN_BRIDGE_GLOBAL_SCALE"] = str(args.global_scale)
+                        env["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
                         gen = os.path.join(
                             Path(__file__).parent,
                             "inference",
@@ -544,9 +615,23 @@ def train(args: argparse.Namespace) -> None:
                             f'--ckpt_dir "{args.transformer_weights_dir or os.path.dirname(args.transformer_weights)}" '
                             f"--size {args.sample_size} --frame_num {args.sample_frame_num} "
                             f"--sample_steps {args.sample_steps} --sample_guide_scale {args.sample_guide_scale} "
+                            f"--t5_cpu --offload_model True "
                             f"--base_seed {args.sample_seed}"
                         )
-                        _run_sampler_batch(gen, prompts, samp_dir, base, ck_step, env)
+                        if args.sample_pause_training:
+                            _release_training_gpu(
+                                [model, teacher_enc, bridge_enc, optim]
+                            )
+                        try:
+                            _run_sampler_batch(
+                                gen, prompts, samp_dir, base, ck_step, env
+                            )
+                        finally:
+                            if args.sample_pause_training:
+                                model, teacher_enc, bridge_enc, optim = (
+                                    _rebuild_training(cfg, args)
+                                )
+                                optim.zero_grad(set_to_none=True)
                     except Exception as e:
                         print(f"[sample] failed to auto-sample: {e}")
 
@@ -659,6 +744,13 @@ def build_argparser() -> argparse.ArgumentParser:
     p.add_argument(
         "--bf16", action="store_true", help="Use bfloat16 precision for encoders"
     )
+    p.add_argument(
+        "--enc_device",
+        type=str,
+        default="cpu",
+        choices=["cpu", "cuda"],
+        help="Device for T5 teacher/Bridge encoders (CPU saves a lot of VRAM).",
+    )
     # Resume options
     p.add_argument(
         "--resume_adapter",
@@ -716,11 +808,16 @@ def build_argparser() -> argparse.ArgumentParser:
         help="How many prompts from the file to sample each time",
     )
     p.add_argument("--sample_task", type=str, default="ti2v-5B")
-    p.add_argument("--sample_size", type=str, default="1280*720")
-    p.add_argument("--sample_steps", type=int, default=50)
+    p.add_argument("--sample_size", type=str, default="768*432")
+    p.add_argument("--sample_steps", type=int, default=20)
     p.add_argument("--sample_guide_scale", type=float, default=5.5)
-    p.add_argument("--sample_frame_num", type=int, default=33)
+    p.add_argument("--sample_frame_num", type=int, default=17)
     p.add_argument("--sample_seed", type=int, default=12345)
+    p.add_argument(
+        "--sample_pause_training",
+        action="store_true",
+        help="Free GPU before sampling (delete models/optimizer), then rebuild after.",
+    )
     p.add_argument(
         "--save_every_epochs",
         type=int,


### PR DESCRIPTION
## Summary
- add `--enc_device` to run teacher and bridge encoders on CPU and move tokens to GPU only for DiT
- make sampler lighter, pass `--t5_cpu`, and optionally pause training to free VRAM
- honor CPU text-encoder in inference pipelines

## Testing
- `ruff check train_kv_lora_distill.py inference/Wan2.2/wan/textimage2video.py inference/Wan2.2/wan/text2video.py inference/Wan2.2/wan/image2video.py inference/Wan2.2/wan/speech2video.py`
- `black train_kv_lora_distill.py inference/Wan2.2/wan/textimage2video.py inference/Wan2.2/wan/text2video.py inference/Wan2.2/wan/image2video.py inference/Wan2.2/wan/speech2video.py`
- `pytest` *(fails: Repo id must be in the form 'repo_name' or 'namespace/repo_name')*


------
https://chatgpt.com/codex/tasks/task_e_68afc37ae60c83238f47132be8e10c47