### PR TITLE
feat: configurable sampling for kv-lora

### DIFF
--- a/inference/Wan2.2/generate.py
+++ b/inference/Wan2.2/generate.py
@@ -10,10 +10,11 @@ import random
 # Allow running without PYTHONPATH set to repo root
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 try:
-    from kv_lora_inject import inject_lora_kv, load_peft_adapter
+    from kv_lora_inject import inject_lora_kv, load_peft_adapter, LoRALinear
 except Exception:
     inject_lora_kv = None
     load_peft_adapter = None
+    LoRALinear = None
 
 import torch
 import torch.distributed as dist
@@ -423,6 +424,16 @@ def generate(args):
             convert_model_dtype=args.convert_model_dtype,
         )
         _maybe_load_kv_lora(wan_t2v, args, logging)
+        if args.lora_adapter_path and LoRALinear is not None:
+            target = (
+                getattr(wan_t2v, "model", None)
+                or getattr(wan_t2v, "dit", None)
+                or wan_t2v
+            )
+            n = sum(1 for _ in target.modules() if isinstance(_, LoRALinear))
+            logging.info(
+                f"KV-LoRA active: {n} modules (alpha={args.lora_alpha}, prefix={args.lora_prefix})"
+            )
 
         logging.info("Generating video ...")
         video = wan_t2v.generate(
@@ -450,6 +461,16 @@ def generate(args):
             convert_model_dtype=args.convert_model_dtype,
         )
         _maybe_load_kv_lora(wan_ti2v, args, logging)
+        if args.lora_adapter_path and LoRALinear is not None:
+            target = (
+                getattr(wan_ti2v, "model", None)
+                or getattr(wan_ti2v, "dit", None)
+                or wan_ti2v
+            )
+            n = sum(1 for _ in target.modules() if isinstance(_, LoRALinear))
+            logging.info(
+                f"KV-LoRA active: {n} modules (alpha={args.lora_alpha}, prefix={args.lora_prefix})"
+            )
 
         logging.info("Generating video ...")
         video = wan_ti2v.generate(
@@ -479,6 +500,16 @@ def generate(args):
             convert_model_dtype=args.convert_model_dtype,
         )
         _maybe_load_kv_lora(wan_s2v, args, logging)
+        if args.lora_adapter_path and LoRALinear is not None:
+            target = (
+                getattr(wan_s2v, "model", None)
+                or getattr(wan_s2v, "dit", None)
+                or wan_s2v
+            )
+            n = sum(1 for _ in target.modules() if isinstance(_, LoRALinear))
+            logging.info(
+                f"KV-LoRA active: {n} modules (alpha={args.lora_alpha}, prefix={args.lora_prefix})"
+            )
         logging.info("Generating video ...")
         video = wan_s2v.generate(
             input_prompt=args.prompt,
@@ -511,6 +542,16 @@ def generate(args):
             convert_model_dtype=args.convert_model_dtype,
         )
         _maybe_load_kv_lora(wan_i2v, args, logging)
+        if args.lora_adapter_path and LoRALinear is not None:
+            target = (
+                getattr(wan_i2v, "model", None)
+                or getattr(wan_i2v, "dit", None)
+                or wan_i2v
+            )
+            n = sum(1 for _ in target.modules() if isinstance(_, LoRALinear))
+            logging.info(
+                f"KV-LoRA active: {n} modules (alpha={args.lora_alpha}, prefix={args.lora_prefix})"
+            )
 
         logging.info("Generating video ...")
         video = wan_i2v.generate(

--- a/train_kv_lora_distill.py
+++ b/train_kv_lora_distill.py
@@ -324,7 +324,13 @@ def _rebuild_training(cfg, args):
 
 
 def _run_sampler_batch(
-    gen_script, prompts, ckpt_dir, save_dir, args, adapter_path=None
+    gen_script,
+    prompts,
+    ckpt_dir,
+    save_dir,
+    args,
+    adapter_path=None,
+    mode="lora_only",
 ):
     os.makedirs(save_dir, exist_ok=True)
     env = os.environ.copy()
@@ -345,16 +351,20 @@ def _run_sampler_batch(
             f"--base_seed {args.sample_seed} --prompt {shlex.quote(prompt)} "
             f'--save_file "{base_out}" --offload_model True {t5flag}'
         )
-        subprocess.run(shlex.split(cmd_base), env=env, check=False)
+        if mode in ("both", "baseline_only"):
+            print(f"[sample] baseline -> {base_out}")
+            subprocess.run(shlex.split(cmd_base), env=env, check=True)
 
-        if adapter_path:
+        if adapter_path and mode in ("both", "lora_only"):
             lora_out = base_out.replace("baseline.mp4", "lora.mp4")
             cmd_lora = (
                 cmd_base
-                + f' --lora_adapter_path "{adapter_path}" --lora_prefix {args.adapter_prefix} --lora_alpha {args.alpha} '
+                + f' --lora_adapter_path "{adapter_path}"'
+                + f" --lora_prefix {args.adapter_prefix} --lora_alpha {args.alpha} "
                 + f' --save_file "{lora_out}"'
             )
-            subprocess.run(shlex.split(cmd_lora), env=env, check=False)
+            print(f"[sample] lora     -> {lora_out} (adapter={adapter_path})")
+            subprocess.run(shlex.split(cmd_lora), env=env, check=True)
 
 
 # -----------------------------------------------------------------------------
@@ -513,7 +523,8 @@ def train(args: argparse.Namespace) -> None:
             ),
             save_dir=samp_dir,
             args=args,
-            adapter_path=zero_path,
+            adapter_path=(zero_path if args.sample_lora_at_first else None),
+            mode=("both" if args.sample_lora_at_first else "baseline_only"),
         )
         if args.sample_pause_training:
             model, teacher_enc, bridge_enc, optim = _rebuild_training(cfg, args)
@@ -638,6 +649,7 @@ def train(args: argparse.Namespace) -> None:
                             save_dir=samp_dir,
                             args=args,
                             adapter_path=ck_step,
+                            mode=args.sample_mode,
                         )
                     except Exception as e:
                         print(f"[sample] failed to auto-sample: {e}")
@@ -819,6 +831,13 @@ def build_argparser() -> argparse.ArgumentParser:
     p.add_argument("--sample_guide_scale", type=float, default=5.5)
     p.add_argument("--sample_frame_num", type=int, default=17)
     p.add_argument("--sample_seed", type=int, default=12345)
+    p.add_argument(
+        "--sample_mode",
+        type=str,
+        default="lora_only",
+        choices=["both", "lora_only", "baseline_only"],
+        help="What to render at sampling points. Default lora_only (after the first baseline).",
+    )
     p.add_argument(
         "--sample_at_first",
         action="store_true",


### PR DESCRIPTION
## Summary
- add sampling mode knob and early sampling flags to trainer
- print sample paths and fail on LoRA errors
- log active KV-LoRA modules when loading adapters

## Testing
- `ruff check train_kv_lora_distill.py inference/Wan2.2/generate.py`
- `black train_kv_lora_distill.py inference/Wan2.2/generate.py`
- `pytest` *(fails: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/workspace/models/MythoMax-L2-13B')*

------
https://chatgpt.com/codex/tasks/task_e_68afdadf61c883238b11579666c90401