### PR TITLE
Add LLM dimension mismatch check to bridge loader

### DIFF
--- a/inference/Wan2.2/wan/modules/t5_bridge.py
+++ b/inference/Wan2.2/wan/modules/t5_bridge.py
@@ -239,6 +239,16 @@ class BridgeEncoderModel:
 
         ckpt = torch.load(self.ckpt_path, map_location="cpu")
         sd = ckpt.get("bridge", ckpt)
+        w = sd.get("in_proj.weight", None)
+        if w is not None:
+            d_llm_ckpt = w.shape[1]
+            d_llm_live = getattr(self.llm.config, "hidden_size", None)
+            if d_llm_live != d_llm_ckpt:
+                raise RuntimeError(
+                    f"Bridge/LLM mismatch: ckpt expects d_llm={d_llm_ckpt} but loaded LLM has d_llm={d_llm_live}. "
+                    "Fix by (A) installing transformers/qwen-vl-utils so Qwen2_5_VL loads, or "
+                    "(B) retraining the bridge for the current LLM dimension."
+                )
         missing, unexpected = self.bridge.load_state_dict(sd, strict=False)
         if missing or unexpected:
             print(

--- a/test/test_t5_bridge_dim_mismatch.py
+++ b/test/test_t5_bridge_dim_mismatch.py
@@ -1,0 +1,55 @@
+import importlib.util
+import types
+import torch
+import torch.nn as nn
+import pytest
+
+T5_BRIDGE_PATH = (
+    __import__("pathlib").Path(__file__).resolve().parents[1]
+    / "inference"
+    / "Wan2.2"
+    / "wan"
+    / "modules"
+    / "t5_bridge.py"
+)
+spec = importlib.util.spec_from_file_location("t5_bridge", T5_BRIDGE_PATH)
+t5_bridge = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(t5_bridge)
+BridgeEncoderModel = t5_bridge.BridgeEncoderModel
+
+
+class DummyLLM(nn.Module):
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.config = types.SimpleNamespace(hidden_size=hidden_size)
+
+    def forward(self, *args, **kwargs):  # pragma: no cover - not used
+        return None
+
+
+def test_bridge_dim_mismatch(tmp_path, monkeypatch):
+    ckpt_path = tmp_path / "bridge.pth"
+    torch.save({"bridge": {"in_proj.weight": torch.zeros(1024, 3584)}}, ckpt_path)
+
+    dummy_llm = DummyLLM(hidden_size=5120)
+
+    monkeypatch.setenv("WAN_BRIDGE_LLM_DIR", "dummy")
+    monkeypatch.setenv("WAN_BRIDGE_CKPT", str(ckpt_path))
+    monkeypatch.setenv("WAN_TEXT_LEN", "16")
+    monkeypatch.setenv("WAN_TEXT_DIM", "8")
+
+    monkeypatch.setattr(
+        t5_bridge.AutoTokenizer,
+        "from_pretrained",
+        lambda *a, **k: object(),
+    )
+    monkeypatch.setattr(
+        t5_bridge.AutoModelForCausalLM,
+        "from_pretrained",
+        lambda *a, **k: dummy_llm,
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        BridgeEncoderModel(text_len=16, device="cpu")
+    assert "Bridge/LLM mismatch" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- ensure BridgeEncoderModel errors when LLM hidden size differs from bridge checkpoint
- add unit test for BridgeEncoderModel dimension mismatch handling

## Testing
- `ruff check inference/Wan2.2/wan/modules/t5_bridge.py test/test_t5_bridge_dim_mismatch.py`
- `black --check inference/Wan2.2/wan/modules/t5_bridge.py test/test_t5_bridge_dim_mismatch.py`
- `pytest -q` *(fails: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/workspace/models/MythoMax-L2-13B')*
- `pytest test/test_lora_filter.py test/test_t5_bridge_dim_mismatch.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b24b52cda883238b5aadfd4c7b1059