### PR TITLE
Add mixed media dataset and sampler for stage-2 training

### DIFF
--- a/mixed_media.py
+++ b/mixed_media.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+import os, re, math, random, pathlib
+from dataclasses import dataclass
+from typing import List, Tuple, Dict, Optional
+import torch
+from torch.utils.data import Dataset, Sampler
+from torchvision.io import read_image, ImageReadMode, read_video
+import torchvision.transforms.functional as TF
+
+IMG_EXT = {".png", ".jpg", ".jpeg", ".webp"}
+VID_EXT = {".mp4", ".webm", ".mkv", ".mov"}
+
+
+@dataclass
+class Sample:
+    path: str
+    txt: str
+    is_video: bool
+    res: int  # 480 or 720
+    frames: int  # 1 for images; else 17/33/49/65/81
+    bucket: Tuple[int, int]  # (res, frames)
+
+
+def _caption_path(stem: str) -> str:
+    alt = stem + ".txt"
+    return alt if os.path.exists(alt) else ""
+
+
+def _infer_frames_from_path(path: str, default_frames: List[int]) -> int:
+    # Expect folder names like ".../17frames", ".../33frames"
+    m = re.search(r"(\d+)frames", path.replace("\\", "/"))
+    if m:
+        return int(m.group(1))
+    return default_frames[-1]  # fallback for videos placed directly in 480p/720p
+
+
+def _norm_to_range(x: torch.Tensor) -> torch.Tensor:
+    # uint8 -> float32 in [-1,1]
+    if x.dtype != torch.float32:
+        x = x.float()
+    return (x / 255.0) * 2.0 - 1.0
+
+
+class MixedCaptioned(Dataset):
+    """
+    Recursively scans:
+      /data/image/{480p,720p}/*.png + .txt pairs
+      /data/video/{480p,720p}/{17frames,33frames,...}/*.mp4 + .txt pairs
+    """
+
+    def __init__(
+        self,
+        root: str,
+        frames_options: List[int],  # e.g. [1,17] or [1,17,33,49,65,81]
+        resolutions: List[int],  # e.g. [480,720]
+        center_crop: bool = True,
+        seed: int = 0,
+    ):
+        super().__init__()
+        assert 1 in frames_options, "Include 1 in --frames so images are supported."
+        self.root = pathlib.Path(root)
+        self.frames_options = sorted(frames_options)
+        self.resolutions = sorted(resolutions)
+        self.center_crop = center_crop
+        self.rng = random.Random(seed)
+
+        self.samples: List[Sample] = []
+        for part in ["image", "video"]:
+            for res in self.resolutions:
+                base = self.root / part / f"{res}p"
+                if not base.exists():
+                    continue
+                if part == "image":
+                    for p in base.rglob("*"):
+                        if p.suffix.lower() in IMG_EXT:
+                            txt = _caption_path(p.with_suffix("").as_posix())
+                            if not txt:
+                                continue
+                            self.samples.append(
+                                Sample(
+                                    path=p.as_posix(),
+                                    txt=txt,
+                                    is_video=False,
+                                    res=res,
+                                    frames=1,
+                                    bucket=(res, 1),
+                                )
+                            )
+                else:
+                    # video case: look under Nframes folders
+                    for p in base.rglob("*"):
+                        if p.suffix.lower() in VID_EXT:
+                            txt = _caption_path(p.with_suffix("").as_posix())
+                            if not txt:
+                                continue
+                            nfrm = _infer_frames_from_path(
+                                p.as_posix(), self.frames_options
+                            )
+                            if nfrm not in self.frames_options:
+                                # skip videos with a frame count we didn't ask to train
+                                continue
+                            self.samples.append(
+                                Sample(
+                                    path=p.as_posix(),
+                                    txt=txt,
+                                    is_video=True,
+                                    res=res,
+                                    frames=nfrm,
+                                    bucket=(res, nfrm),
+                                )
+                            )
+        if not self.samples:
+            raise RuntimeError(
+                f"No (image|video)+caption pairs found under {self.root}"
+            )
+
+        # Buckets -> indices
+        self.buckets: Dict[Tuple[int, int], List[int]] = {}
+        for i, s in enumerate(self.samples):
+            self.buckets.setdefault(s.bucket, []).append(i)
+        for k in self.buckets:
+            self.rng.shuffle(self.buckets[k])
+
+    def __len__(self):
+        return len(self.samples)
+
+    def _resize_and_crop(self, x: torch.Tensor, target: int) -> torch.Tensor:
+        # x: [C,H,W], uint8 or float; output float32 in [-1,1]; square or keep aspect, shortest side -> target
+        C, H, W = x.shape
+        # make shortest side == target, keep aspect
+        scale = target / min(H, W)
+        newH = int(round(H * scale))
+        newW = int(round(W * scale))
+        x = TF.resize(x, [newH, newW], antialias=True)
+        # center/ random crop to (target,target) if needed
+        if newH != target or newW != target:
+            top = (
+                (newH - target) // 2
+                if self.center_crop
+                else self.rng.randint(0, newH - target)
+            )
+            left = (
+                (newW - target) // 2
+                if self.center_crop
+                else self.rng.randint(0, newW - target)
+            )
+            x = TF.crop(x, top, left, target, target)
+        return _norm_to_range(x)
+
+    def _load_image_tensor(self, path: str, target: int) -> torch.Tensor:
+        # returns [T=1, 3, H, W] normalized [-1,1]
+        im = read_image(path, mode=ImageReadMode.RGB)  # [3,H,W], uint8
+        im = self._resize_and_crop(im, target)
+        return im.unsqueeze(0)  # [1,3,H,W]
+
+    def _load_video_tensor(self, path: str, target: int, nframes: int) -> torch.Tensor:
+        # decode then uniform-sample nframes
+        # read_video returns (video[T,H,W,C], audio, info); video is float32 0..255
+        v, _, info = read_video(path, pts_unit="sec")
+        if v.ndim != 4:
+            raise RuntimeError(f"Bad video tensor for {path}: {v.shape}")
+        total = v.shape[0]
+        if total < nframes:
+            # loop-pad
+            reps = math.ceil(nframes / total)
+            v = v.repeat(reps, 1, 1, 1)[:nframes]
+        else:
+            idx = torch.linspace(0, total - 1, nframes).round().long()
+            v = v.index_select(0, idx)
+
+        # [T,H,W,C] -> list of [3,H,W] tensors
+        frames = v.permute(0, 3, 1, 2).contiguous()  # [T,3,H,W], 0..255 float
+        out = []
+        for i in range(frames.size(0)):
+            out.append(self._resize_and_crop(frames[i], target))  # [3,h,w]
+        return torch.stack(out, dim=0)  # [T,3,h,w] in [-1,1]
+
+    def __getitem__(self, idx):
+        s = self.samples[idx]
+        with open(s.txt, "r", encoding="utf-8") as f:
+            caption = f.read().strip()
+
+        if s.is_video:
+            x = self._load_video_tensor(s.path, s.res, s.frames)  # [T,3,h,w]
+        else:
+            x = self._load_image_tensor(s.path, s.res)  # [1,3,h,w]
+        return dict(
+            pixel=x,  # normalized [-1,1]
+            caption=caption,
+            res=s.res,
+            frames=s.frames,
+            is_video=s.is_video,
+        )
+
+
+class BucketBatchSampler(Sampler[List[int]]):
+    """
+    Yields index lists such that each batch has the same (res,frames) bucket.
+    You pass a map bucket->indices and a per-bucket batch size table.
+    """
+
+    def __init__(
+        self,
+        dataset: MixedCaptioned,
+        batch_sizes: Dict[Tuple[int, int], int],
+        seed: int = 0,
+    ):
+        self.ds = dataset
+        self.batch_sizes = batch_sizes
+        self.rng = random.Random(seed)
+        # clone + shuffle pointers for each bucket
+        self.ptrs: Dict[Tuple[int, int], int] = {k: 0 for k in self.ds.buckets}
+
+    def __iter__(self):
+        # cycle buckets round-robin
+        keys = list(self.ds.buckets.keys())
+        self.rng.shuffle(keys)
+        while True:
+            made_any = False
+            for k in keys:
+                inds = self.ds.buckets[k]
+                bs = self.batch_sizes.get(k, 1)
+                p = self.ptrs[k]
+                if p >= len(inds):
+                    continue
+                made_any = True
+                q = min(p + bs, len(inds))
+                self.ptrs[k] = q
+                yield inds[p:q]
+            if not made_any:
+                break
+
+    def __len__(self):
+        # approximate (number of batches across all buckets)
+        total = 0
+        for k, inds in self.ds.buckets.items():
+            bs = self.batch_sizes.get(k, 1)
+            total += math.ceil(len(inds) / bs)
+        return total

--- a/train_lora_stage_2.py
+++ b/train_lora_stage_2.py
@@ -13,51 +13,19 @@ Stage-2 LoRA trainer for Wan DiT cross-attention (Q/K/V/O) on captioned image+vi
 """
 
 from __future__ import annotations
-import glob
 import json
 import os
 import random
 import sys
-from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Tuple, Optional, Dict
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.utils.data import Dataset, DataLoader
-from torchvision.io import read_image, ImageReadMode
-from torchvision.io import read_video  # fallback video decoder
-from torchvision.transforms.functional import resize, center_crop
-
-# ---- torchvision dtype shim (works across torchvision versions) ----
-try:
-    # Newer builds may have to_dtype; keep its behavior if present.
-    from torchvision.transforms.functional import to_dtype as _tv_to_dtype
-
-    def to_dtype(img, dtype, scale: bool = True):
-        # mirror the signature we use later in the file
-        return _tv_to_dtype(img, dtype=dtype, scale=scale)
-
-except Exception:
-    # Fallback for common builds: use convert_image_dtype (scales ints->[0,1] when going to float)
-    from torchvision.transforms.functional import (
-        convert_image_dtype as _convert_image_dtype,
-    )
-    import torch
-
-    def to_dtype(img, dtype, scale: bool = True):
-        # If we're converting integer tensors to float and scale=True, convert_image_dtype
-        # will scale to [0,1]. If scale=False, just cast.
-        if scale:
-            return _convert_image_dtype(img, dtype)
-        else:
-            return img.to(dtype)
-
-
+from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-# ---- local imports
 from kv_lora_inject import (
     inject_lora_kv,
     set_lora_enabled,
@@ -66,6 +34,7 @@ from kv_lora_inject import (
     export_peft_adapter,
     LoRALinear,
 )
+from mixed_media import MixedCaptioned, BucketBatchSampler
 
 # --- Configuration / args
 import argparse
@@ -140,28 +109,25 @@ def build_argparser():
         required=True,
         help="Root folder (contains /image, /video).",
     )
-    p.add_argument("--use_480p", action="store_true")
-    p.add_argument("--use_720p", action="store_true")
+    p.add_argument(
+        "--resolutions",
+        type=str,
+        default="480,720",
+        help="Comma list of resolutions to include (e.g. 480,720).",
+    )
     p.add_argument(
         "--frames",
         type=str,
-        default="17,33,49,65,81",
-        help="Which frame-count folders to include for videos.",
+        default="1,17",
+        help="Which frame-count buckets to include (must include 1 for images).",
     )
     p.add_argument(
-        "--max_samples",
+        "--base_batch",
         type=int,
-        default=None,
-        help="Optional cap on total samples (images+videos).",
+        default=16,
+        help="Reference batch size for 480p images; other buckets scale from this.",
     )
-    p.add_argument("--shuffle", action="store_true")
-    p.add_argument(
-        "--batch_size",
-        type=int,
-        default=1,
-        help="Batch size in videos usually must be small.",
-    )
-    p.add_argument("--num_workers", type=int, default=4)
+    p.add_argument("--workers", type=int, default=4, help="DataLoader workers.")
 
     # Training
     p.add_argument("--steps", type=int, default=20000)
@@ -196,154 +162,6 @@ def _import_wan22():
     from wan.modules.t5_bridge import BridgeEncoderModel  # type: ignore
 
     return WanModel, BridgeEncoderModel
-
-
-# ---- Data helpers
-
-
-def _read_caption(txt_path: str) -> str:
-    try:
-        with open(txt_path, "r", encoding="utf-8") as f:
-            t = f.read().strip()
-            return t if t else " "
-    except Exception:
-        return " "
-
-
-def _norm_to_minus1_1(t: torch.Tensor) -> torch.Tensor:
-    # t in [0,1] float -> [-1,1]
-    return t * 2.0 - 1.0
-
-
-def _load_image(path: str, side: int) -> torch.Tensor:
-    # returns [T=1, H, W, C]
-    img = read_image(path, mode=ImageReadMode.RGB)  # [3,H,W], uint8
-    img = to_dtype(img, torch.float32, scale=True)  # -> [0,1]
-    # make square crop to preserve aspect before resizing (Wan uses fixed res)
-    H, W = img.shape[1], img.shape[2]
-    s = min(H, W)
-    img = center_crop(img, [s, s])
-    img = resize(img, [side, side], antialias=True)
-    img = img.permute(1, 2, 0).contiguous()  # [H,W,3]
-    img = _norm_to_minus1_1(img)
-    return img.unsqueeze(0)  # [1,H,W,3]
-
-
-def _ensure_nframes(frames: torch.Tensor, target_T: int) -> torch.Tensor:
-    # frames: [T,H,W,3] in [-1,1]
-    T = frames.shape[0]
-    if T == target_T:
-        return frames
-    if T > target_T:
-        # uniform downsample
-        idx = torch.linspace(0, T - 1, target_T).round().long()
-        return frames.index_select(0, idx)
-    # pad last frame
-    last = frames[-1:].repeat(target_T - T, 1, 1, 1)
-    return torch.cat([frames, last], dim=0)
-
-
-def _load_video(path: str, side: int, target_T: int) -> torch.Tensor:
-    # returns [T,H,W,3]
-    # Note: torchvision.io.read_video returns T,H,W,C in uint8 (or float)
-    vframes, _, _ = read_video(path, pts_unit="sec")
-    vframes = to_dtype(vframes, torch.float32, scale=True)  # [T,H,W,3] in [0,1]
-    # center-crop shortest side then resize square
-    H, W = int(vframes.shape[1]), int(vframes.shape[2])
-    s = min(H, W)
-    top = (H - s) // 2
-    left = (W - s) // 2
-    vframes = vframes[:, top : top + s, left : left + s, :]
-    # resize per-frame
-    vframes = torch.stack(
-        [
-            resize(f.permute(2, 0, 1), [side, side], antialias=True).permute(1, 2, 0)
-            for f in vframes
-        ],
-        dim=0,
-    )
-    vframes = _norm_to_minus1_1(vframes)
-    vframes = _ensure_nframes(vframes, target_T)
-    return vframes  # [T,H,W,3]
-
-
-@dataclass
-class MediaSample:
-    kind: str  # "image" or "video"
-    path: str
-    caption: str
-    reso: int  # 480 or 720
-    frames: int  # 1 for images, else one of {17,33,49,65,81}
-
-
-class MediaDataset(Dataset):
-    def __init__(
-        self,
-        root: str,
-        use_480p: bool,
-        use_720p: bool,
-        frames_list: List[int],
-        max_samples: Optional[int] = None,
-        shuffle: bool = False,
-    ):
-        root = Path(root)
-        items: List[MediaSample] = []
-
-        def scan_img(reso: int):
-            d = root / "image" / f"{reso}p"
-            for img in glob.glob(str(d / "*")):
-                if os.path.splitext(img)[1].lower() not in (
-                    ".png",
-                    ".jpg",
-                    ".jpeg",
-                    ".bmp",
-                    ".webp",
-                ):
-                    continue
-                cap = os.path.splitext(img)[0] + ".txt"
-                items.append(MediaSample("image", img, _read_caption(cap), reso, 1))
-
-        def scan_vid(reso: int):
-            vd = root / "video" / f"{reso}p"
-            for T in frames_list:
-                td = vd / f"{T}frames"
-                for mp4 in glob.glob(str(td / "*.mp4")):
-                    cap = os.path.splitext(mp4)[0] + ".txt"
-                    items.append(MediaSample("video", mp4, _read_caption(cap), reso, T))
-
-        if use_480p:
-            scan_img(480)
-            scan_vid(480)
-        if use_720p:
-            scan_img(720)
-            scan_vid(720)
-
-        if shuffle:
-            random.shuffle(items)
-        if max_samples is not None:
-            items = items[:max_samples]
-
-        self.items = items
-
-    def __len__(self):
-        return len(self.items)
-
-    def __getitem__(self, idx: int):
-        s = self.items[idx]
-        side = s.reso
-        if s.kind == "image":
-            frames = _load_image(s.path, side)  # [1,H,W,3]
-        else:
-            frames = _load_video(s.path, side, s.frames)  # [T,H,W,3]
-        return {
-            "kind": s.kind,
-            "path": s.path,
-            "caption": s.caption,
-            "video": frames,  # [T,H,W,3], in [-1,1]
-            "T": frames.shape[0],
-            "H": frames.shape[1],
-            "W": frames.shape[2],
-        }
 
 
 # ---- Text (Bridge) helpers
@@ -543,41 +361,30 @@ def main(args):
     bridge = BridgeEncoderModel(text_len=args.text_len, device=device, dtype=dtype)
 
     # Data
-    frames_list = [int(x) for x in args.frames.split(",") if x.strip()]
-    ds = MediaDataset(
-        args.data_root,
-        args.use_480p,
-        args.use_720p,
-        frames_list=frames_list,
-        max_samples=args.max_samples,
-        shuffle=args.shuffle,
+    frames = [int(x) for x in args.frames.split(",") if x.strip()]
+    reses = [int(x) for x in args.resolutions.split(",") if x.strip()]
+    dataset = MixedCaptioned(
+        root=args.data_root,
+        frames_options=frames,
+        resolutions=reses,
+        center_crop=True,
+        seed=args.seed,
     )
-    if len(ds) == 0:
+    if len(dataset) == 0:
         raise RuntimeError("No samples found under the given config.")
-    print(f"[data] total samples: {len(ds)}")
+    print(f"[data] total samples: {len(dataset)}")
 
-    def _collate(batch):
-        # batch is list of dicts
-        caps = [b["caption"] for b in batch]
-        # pad to max T in batch; stack videos
-        T_max = max(b["video"].shape[0] for b in batch)
-        vids = []
-        for b in batch:
-            v = b["video"]
-            if v.shape[0] != T_max:
-                v = _ensure_nframes(v, T_max)
-            vids.append(v)
-        vids = torch.stack(vids, dim=0)  # [B,T,H,W,3]
-        return {"captions": caps, "video": vids}
+    def guess_bs(res, T, base=16):
+        scale = (1.0 + T / 4.0) * (res / 16.0) ** 2
+        ref = (1.0 + 1 / 4.0) * (480 / 16.0) ** 2
+        return max(1, int(base * ref / scale))
 
+    batch_sizes = {
+        (r, f): guess_bs(r, f, base=args.base_batch) for r in reses for f in frames
+    }
+    sampler = BucketBatchSampler(dataset, batch_sizes, seed=args.seed)
     loader = DataLoader(
-        ds,
-        batch_size=args.batch_size,
-        shuffle=True,
-        num_workers=args.num_workers,
-        pin_memory=True,
-        collate_fn=_collate,
-        drop_last=True,
+        dataset, batch_sampler=sampler, num_workers=args.workers, pin_memory=True
     )
 
     # Optimizer
@@ -598,8 +405,8 @@ def main(args):
         for batch in loader:
             if step >= args.steps:
                 break
-            vids = batch["video"].to(device)  # [B,T,H,W,3], in [-1,1]
-            caps: List[str] = batch["captions"]
+            vids = batch["pixel"].permute(0, 1, 3, 4, 2).to(device)  # [B,T,H,W,3]
+            caps: List[str] = batch["caption"]
 
             # text → tokens → context
             tokens_list = bridge(caps, device)  # list of [L_i, d]


### PR DESCRIPTION
## Summary
- add `mixed_media.py` with MixedCaptioned dataset and BucketBatchSampler
- use mixed-media loader in `train_lora_stage_2.py` with per-bucket batch sizes
- update CLI to accept resolutions and frame buckets

## Testing
- `ruff check train_lora_stage_2.py mixed_media.py`
- `black --check train_lora_stage_2.py mixed_media.py`
- `pytest` *(fails: Repo id must be in the form 'repo_name' or 'namespace/repo_name')*


------
https://chatgpt.com/codex/tasks/task_e_68b24e32986c8323aaf18d441991cbf8