### PR TITLE
fix: add glob import for weight shard loading

### DIFF
--- a/train_lora_stage_2.py
+++ b/train_lora_stage_2.py
@@ -13,12 +13,13 @@ Stage-2 LoRA trainer for Wan DiT cross-attention (Q/K/V/O) on captioned image+vi
 """
 
 from __future__ import annotations
+import glob
 import json
 import os
 import random
 import sys
 from pathlib import Path
-from typing import List, Tuple, Optional, Dict
+from typing import Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn


### PR DESCRIPTION
## Summary
- import `glob` in `train_lora_stage_2.py` to enable weight shard discovery

## Testing
- `python -m black train_lora_stage_2.py`
- `python -m ruff check train_lora_stage_2.py`
- `pytest -q` *(fails: HFValidationError: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/workspace/models/MythoMax-L2-13B')*

------
https://chatgpt.com/codex/tasks/task_e_68b2515168388323abe7cece55920b86