### PR TITLE
Ensure Qwen2.5-VL loads via trust_remote_code

### DIFF
--- a/bridge/precache_features.py
+++ b/bridge/precache_features.py
@@ -70,9 +70,12 @@ def main():
     )
     if is_vl and AutoProcessor and Qwen2_5_VLForConditionalGeneration:
         print("[precache] loading LLM (Qwen-VL)…")
-        proc = AutoProcessor.from_pretrained(args.llm_dir)
+        proc = AutoProcessor.from_pretrained(args.llm_dir, trust_remote_code=True)
         vl = Qwen2_5_VLForConditionalGeneration.from_pretrained(
-            args.llm_dir, torch_dtype=torch.bfloat16, device_map="auto"
+            args.llm_dir,
+            torch_dtype=torch.bfloat16,
+            device_map="auto",
+            trust_remote_code=True,
         )
         vl.eval().requires_grad_(False)
 

--- a/inference/Wan2.2/wan/modules/t5_bridge.py
+++ b/inference/Wan2.2/wan/modules/t5_bridge.py
@@ -203,9 +203,14 @@ class BridgeEncoderModel:
         device_map = "auto" if self.device.type == "cuda" else None
         if Qwen2_5_VLForConditionalGeneration is not None:
             try:
-                self.proc = AutoProcessor.from_pretrained(self.llm_dir)
+                self.proc = AutoProcessor.from_pretrained(
+                    self.llm_dir, trust_remote_code=True
+                )
                 self.llm = Qwen2_5_VLForConditionalGeneration.from_pretrained(
-                    self.llm_dir, torch_dtype=self.dtype, device_map=device_map
+                    self.llm_dir,
+                    torch_dtype=self.dtype,
+                    device_map=device_map,
+                    trust_remote_code=True,
                 )
                 self.is_vl = True
             except Exception:


### PR DESCRIPTION
## Summary
- fix bridge loader to instantiate Qwen2.5-VL with `trust_remote_code=True`
- do the same in `precache_features` so VL checkpoints don't fall back to base LLM

## Testing
- `ruff check bridge/precache_features.py inference/Wan2.2/wan/modules/t5_bridge.py`
- `pytest test/test_t5_bridge_dim_mismatch.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b257cd7aa88323a4b7bb7358e1c67f