### PR TITLE
Harden Qwen-VL bridge loader with explicit fallback guard

### DIFF
--- a/inference/Wan2.2/wan/modules/t5_bridge.py
+++ b/inference/Wan2.2/wan/modules/t5_bridge.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Union
 
 import torch
 import torch.nn as nn
-from transformers import AutoTokenizer, AutoModelForCausalLM, AutoProcessor
+from transformers import AutoProcessor
 
 try:
     from transformers import Qwen2_5_VLForConditionalGeneration
@@ -200,7 +200,13 @@ class BridgeEncoderModel:
 
         # --- load LLM (tokenizer/processor + model) ---
         self.is_vl = False
-        device_map = "auto" if self.device.type == "cuda" else None
+        device_map = "auto" if self.device.type == "cuda" else {"": "cpu"}
+        force_vl = os.environ.get("WAN_BRIDGE_FORCE_VL", "1").lower() not in (
+            "0",
+            "false",
+            "no",
+        )
+
         if Qwen2_5_VLForConditionalGeneration is not None:
             try:
                 self.proc = AutoProcessor.from_pretrained(
@@ -210,16 +216,36 @@ class BridgeEncoderModel:
                     self.llm_dir,
                     torch_dtype=self.dtype,
                     device_map=device_map,
+                    low_cpu_mem_usage=True,
                     trust_remote_code=True,
                 )
                 self.is_vl = True
-            except Exception:
-                pass
+            except Exception as e:
+                if force_vl:
+                    print(
+                        "[BridgeEncoderModel] Qwen2.5-VL load failed; refusing to fall back because "
+                        "WAN_BRIDGE_FORCE_VL is set. Full error:"
+                    )
+                    raise
+                else:
+                    print(
+                        f"[BridgeEncoderModel] Qwen2.5-VL load failed ({e}). Falling back to AutoModelForCausalLM."
+                    )
+
         if not self.is_vl:
-            self.tok = AutoTokenizer.from_pretrained(self.llm_dir, use_fast=True)
-            self.llm = AutoModelForCausalLM.from_pretrained(
-                self.llm_dir, torch_dtype=self.dtype, device_map=device_map
+            from transformers import AutoTokenizer, AutoModelForCausalLM
+
+            self.tok = AutoTokenizer.from_pretrained(
+                self.llm_dir, use_fast=True, trust_remote_code=True
             )
+            self.llm = AutoModelForCausalLM.from_pretrained(
+                self.llm_dir,
+                torch_dtype=self.dtype,
+                device_map=device_map,
+                low_cpu_mem_usage=True,
+                trust_remote_code=True,
+            )
+
         self.llm.eval().requires_grad_(False)
 
         d_llm = getattr(self.llm.config, "hidden_size", None)
@@ -244,15 +270,16 @@ class BridgeEncoderModel:
 
         ckpt = torch.load(self.ckpt_path, map_location="cpu")
         sd = ckpt.get("bridge", ckpt)
-        w = sd.get("in_proj.weight", None)
-        if w is not None:
-            d_llm_ckpt = w.shape[1]
-            d_llm_live = getattr(self.llm.config, "hidden_size", None)
-            if d_llm_live != d_llm_ckpt:
+
+        # If the bridge was saved as raw module weights, pick a canonical key:
+        in_keys = [k for k in sd.keys() if k.endswith("in_proj.weight")]
+        if in_keys:
+            ckpt_d_llm = sd[in_keys[0]].shape[1]
+            if ckpt_d_llm != d_llm:
                 raise RuntimeError(
-                    f"Bridge/LLM mismatch: ckpt expects d_llm={d_llm_ckpt} but loaded LLM has d_llm={d_llm_live}. "
-                    "Fix by (A) installing transformers/qwen-vl-utils so Qwen2_5_VL loads, or "
-                    "(B) retraining the bridge for the current LLM dimension."
+                    f"Bridge/LLM hidden_size mismatch: bridge expects d_llm={ckpt_d_llm}, "
+                    f"but loaded LLM has d_llm={d_llm}. "
+                    "This is almost always due to falling back to a CausalLM or pointing to the wrong LLM repo."
                 )
         missing, unexpected = self.bridge.load_state_dict(sd, strict=False)
         if missing or unexpected:

--- a/scripts/diagnostics/diagnose_qwen_vl.py
+++ b/scripts/diagnostics/diagnose_qwen_vl.py
@@ -1,53 +1,72 @@
 #!/usr/bin/env python3
-import argparse, os, sys, json, platform, traceback
+import argparse
+import platform
+import sys
+import traceback
 from pathlib import Path
 
 import torch
-print = lambda *a, **k: __import__("builtins").print(*a, **k, flush=True)
+
+
+def print(*a, **k):
+    __import__("builtins").print(*a, **k, flush=True)
+
 
 def section(t):
     print("=" * 80)
     print(t)
     print("=" * 80)
 
+
 def _try_imports():
     info = {}
     try:
         import transformers
+
         info["transformers"] = transformers.__version__
     except Exception as e:
         info["transformers"] = f"ERROR: {e}"
     try:
         import qwen_vl_utils  # optional; not always required on transformers>=4.43
+
         info["qwen_vl_utils"] = getattr(qwen_vl_utils, "__version__", "present")
     except Exception:
         info["qwen_vl_utils"] = None
     try:
         import torchvision
+
         info["torchvision"] = torchvision.__version__
     except Exception:
         info["torchvision"] = None
     try:
         import decord
+
         info["decord"] = decord.__version__
     except Exception:
         info["decord"] = None
     return info
+
 
 def env_report():
     section("ENVIRONMENT")
     info = _try_imports()
     print(f"Python      : {platform.python_version()}  ({sys.executable})")
     print(f"Platform    : {platform.platform()}")
-    print(f"torch       : {torch.__version__}  (cuda.is_available={torch.cuda.is_available()})")
+    print(
+        f"torch       : {torch.__version__}  (cuda.is_available={torch.cuda.is_available()})"
+    )
     if torch.cuda.is_available():
-        print(f"CUDA        : {torch.version.cuda}  GPU={torch.cuda.get_device_name(0)}")
-    for k in ("transformers","qwen_vl_utils","torchvision","decord"):
+        print(
+            f"CUDA        : {torch.version.cuda}  GPU={torch.cuda.get_device_name(0)}"
+        )
+    for k in ("transformers", "qwen_vl_utils", "torchvision", "decord"):
         print(f"{k:<12}: {info[k]}")
     return info
 
+
 def load_vl_model(llm_dir, use_cpu=False, verbose=False):
     from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
+
     section("ATTEMPTING TO LOAD Qwen2_5_VLForConditionalGeneration")
     # Processor
     proc = AutoProcessor.from_pretrained(llm_dir, trust_remote_code=True)
@@ -70,11 +89,13 @@ def load_vl_model(llm_dir, use_cpu=False, verbose=False):
         print("model_type  :", getattr(cfg, "model_type", None))
     return proc, model
 
+
 def try_causallm_fallback(llm_dir, use_cpu=False):
     """Mimic the fallback many scripts use and show what hidden_size that gives."""
     from transformers import AutoTokenizer, AutoModelForCausalLM
+
     section("FALLBACK CHECK (AutoModelForCausalLM)")
-    tok = AutoTokenizer.from_pretrained(llm_dir, use_fast=True, trust_remote_code=True)
+    AutoTokenizer.from_pretrained(llm_dir, use_fast=True, trust_remote_code=True)
     dtype = torch.float32 if use_cpu else torch.bfloat16
     device_map = {"": "cpu"} if use_cpu else "auto"
     mdl = AutoModelForCausalLM.from_pretrained(
@@ -87,6 +108,7 @@ def try_causallm_fallback(llm_dir, use_cpu=False):
     hs = getattr(mdl.config, "hidden_size", None)
     print(f"AutoModelForCausalLM -> hidden_size={hs}")
     return mdl
+
 
 def inspect_bridge_ckpt(path):
     section("BRIDGE CHECKPOINT INSPECTION")
@@ -101,18 +123,29 @@ def inspect_bridge_ckpt(path):
     # Find an in-proj weight no matter how it was saved
     cand_keys = [k for k in sd.keys() if k.endswith("in_proj.weight")]
     if not cand_keys:
-        print("Could not find 'in_proj.weight' in ckpt (is this the right bridge file?).")
+        print(
+            "Could not find 'in_proj.weight' in ckpt (is this the right bridge file?)."
+        )
         return None
     k = cand_keys[0]
     in_dim = sd[k].shape[1]
-    print(f"Found {k} with shape {tuple(sd[k].shape)}  -> expected LLM hidden_size={in_dim}")
+    print(
+        f"Found {k} with shape {tuple(sd[k].shape)}  -> expected LLM hidden_size={in_dim}"
+    )
     return in_dim
+
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--llm_dir", required=True, help="HF path or local dir for Qwen2.5-VL")
-    ap.add_argument("--bridge_ckpt", default=None, help="Path to your trained bridge *.pth")
-    ap.add_argument("--cpu", action="store_true", help="Force CPU load for the VL model")
+    ap.add_argument(
+        "--llm_dir", required=True, help="HF path or local dir for Qwen2.5-VL"
+    )
+    ap.add_argument(
+        "--bridge_ckpt", default=None, help="Path to your trained bridge *.pth"
+    )
+    ap.add_argument(
+        "--cpu", action="store_true", help="Force CPU load for the VL model"
+    )
     ap.add_argument("--verbose", action="store_true")
     args = ap.parse_args()
 
@@ -120,9 +153,11 @@ def main():
 
     # 1) Try the VL path (no fallbacks).
     try:
-        _, vl_model = load_vl_model(args.llm_dir, use_cpu=args.cpu, verbose=args.verbose)
+        _, vl_model = load_vl_model(
+            args.llm_dir, use_cpu=args.cpu, verbose=args.verbose
+        )
         vl_hs = getattr(vl_model.config, "hidden_size", None)
-    except Exception as e:
+    except Exception:
         print("\n!!! FAILED TO LOAD Qwen2_5_VLForConditionalGeneration !!!")
         print("Traceback:")
         traceback.print_exc()
@@ -149,16 +184,27 @@ def main():
 
     print("\nSummary:")
     if ckpt_hs is not None and vl_hs is not None and ckpt_hs == vl_hs:
-        print("✔ Your bridge ckpt matches Qwen2.5-VL. Use the VL loader. Do NOT fall back.")
+        print(
+            "✔ Your bridge ckpt matches Qwen2.5-VL. Use the VL loader. Do NOT fall back."
+        )
     if ckpt_hs is not None and clm_hs is not None and ckpt_hs != clm_hs:
-        print("✖ Bridge ckpt does NOT match the CausalLM fallback. If you see 5120 vs 3584,"
-              " you are accidentally using the fallback.")
+        print(
+            "✖ Bridge ckpt does NOT match the CausalLM fallback. If you see 5120 vs 3584,"
+            " you are accidentally using the fallback."
+        )
     if vl_hs is None:
-        print("→ The VL model failed to load in this environment. Fix that first (see traceback above).")
+        print(
+            "→ The VL model failed to load in this environment. Fix that first (see traceback above)."
+        )
     print("\nActionable next step:")
-    print("  Run training with WAN_BRIDGE_FORCE_VL=1 so the code raises instead of silently falling back.")
+    print(
+        "  Run training with WAN_BRIDGE_FORCE_VL=1 so the code raises instead of silently falling back."
+    )
     print("  Example:")
-    print("    WAN_BRIDGE_FORCE_VL=1 python train_lora_stage_2.py ... --llm_dir <your-qwen-vl-repo> ...")
+    print(
+        "    WAN_BRIDGE_FORCE_VL=1 python train_lora_stage_2.py ... --llm_dir <your-qwen-vl-repo> ..."
+    )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- make `BridgeEncoderModel` fail fast if Qwen2.5-VL fails to load
- validate bridge checkpoint hidden size before loading
- clean up Qwen-VL diagnostic script to satisfy ruff

## Testing
- `python -m black scripts/diagnostics/diagnose_qwen_vl.py inference/Wan2.2/wan/modules/t5_bridge.py`
- `ruff check inference/Wan2.2/wan/modules/t5_bridge.py scripts/diagnostics/diagnose_qwen_vl.py`
- `python scripts/diagnostics/diagnose_qwen_vl.py --llm_dir thesby/Qwen2.5-VL-7B-NSFW-Caption-V3 --cpu --verbose` *(fails: ProxyError)*


------
https://chatgpt.com/codex/tasks/task_e_68b264c7f0908323aaa800d44fb26ca9