### PR TITLE
Load Wan VAE explicitly and improve frame handling

### DIFF
--- a/mixed_media.py
+++ b/mixed_media.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
-import os, re, math, random, pathlib
+import math
+import os
+import pathlib
+import random
+import re
 from dataclasses import dataclass
-from typing import List, Tuple, Dict, Optional
+from typing import Dict, List, Tuple
 import torch
 from torch.utils.data import Dataset, Sampler
 from torchvision.io import read_image, ImageReadMode, read_video
@@ -26,19 +30,25 @@ def _caption_path(stem: str) -> str:
     return alt if os.path.exists(alt) else ""
 
 
-def _infer_frames_from_path(path: str, default_frames: List[int]) -> int:
-    # Expect folder names like ".../17frames", ".../33frames"
+def _infer_frames_from_path(path: str, allowed: List[int]) -> int:
+    """Pick a frame count from the path or the closest allowed value."""
     m = re.search(r"(\d+)frames", path.replace("\\", "/"))
     if m:
-        return int(m.group(1))
-    return default_frames[-1]  # fallback for videos placed directly in 480p/720p
+        try:
+            want = int(m.group(1))
+            if want in allowed:
+                return want
+        except Exception:
+            pass
+    vids = [x for x in allowed if x != 1]
+    return min(vids, key=lambda v: abs(v - 17)) if vids else 17
 
 
 def _norm_to_range(x: torch.Tensor) -> torch.Tensor:
-    # uint8 -> float32 in [-1,1]
+    # uint8 -> float32 in [0,1]
     if x.dtype != torch.float32:
         x = x.float()
-    return (x / 255.0) * 2.0 - 1.0
+    return x / 255.0
 
 
 class MixedCaptioned(Dataset):
@@ -125,7 +135,7 @@ class MixedCaptioned(Dataset):
         return len(self.samples)
 
     def _resize_and_crop(self, x: torch.Tensor, target: int) -> torch.Tensor:
-        # x: [C,H,W], uint8 or float; output float32 in [-1,1]; square or keep aspect, shortest side -> target
+        # x: [C,H,W], uint8 or float; output float32 in [0,1]; square or keep aspect, shortest side -> target
         C, H, W = x.shape
         # make shortest side == target, keep aspect
         scale = target / min(H, W)
@@ -148,7 +158,7 @@ class MixedCaptioned(Dataset):
         return _norm_to_range(x)
 
     def _load_image_tensor(self, path: str, target: int) -> torch.Tensor:
-        # returns [T=1, 3, H, W] normalized [-1,1]
+        # returns [T=1, 3, H, W] normalized [0,1]
         im = read_image(path, mode=ImageReadMode.RGB)  # [3,H,W], uint8
         im = self._resize_and_crop(im, target)
         return im.unsqueeze(0)  # [1,3,H,W]
@@ -173,7 +183,7 @@ class MixedCaptioned(Dataset):
         out = []
         for i in range(frames.size(0)):
             out.append(self._resize_and_crop(frames[i], target))  # [3,h,w]
-        return torch.stack(out, dim=0)  # [T,3,h,w] in [-1,1]
+        return torch.stack(out, dim=0)  # [T,3,h,w] in [0,1]
 
     def __getitem__(self, idx):
         s = self.samples[idx]
@@ -185,7 +195,7 @@ class MixedCaptioned(Dataset):
         else:
             x = self._load_image_tensor(s.path, s.res)  # [1,3,h,w]
         return dict(
-            pixel=x,  # normalized [-1,1]
+            pixel=x,  # normalized [0,1]
             caption=caption,
             res=s.res,
             frames=s.frames,

--- a/train_lora_stage_2.py
+++ b/train_lora_stage_2.py
@@ -36,6 +36,7 @@ from kv_lora_inject import (
     LoRALinear,
 )
 from mixed_media import MixedCaptioned, BucketBatchSampler
+from wan_vae_loader import load_wan_vae
 
 # --- Configuration / args
 import argparse
@@ -61,6 +62,18 @@ def build_argparser():
         type=str,
         default=None,
         help="Single .safetensors (optional if --transformer_weights_dir set).",
+    )
+    p.add_argument(
+        "--vae_dir",
+        type=str,
+        default=os.environ.get("WAN_VAE_DIR", None),
+        help="Folder containing Wan VAE weights.",
+    )
+    p.add_argument(
+        "--vae_ckpt",
+        type=str,
+        default=os.environ.get("WAN_VAE_CKPT", None),
+        help="Path to Wan VAE .safetensors checkpoint.",
     )
     p.add_argument("--text_len", type=int, default=512)
 
@@ -247,32 +260,32 @@ def call_dit(
     return model(x_t, t, context)
 
 
-def encode_video_to_latents(model, video_bthwc: torch.Tensor) -> torch.Tensor:
-    """
-    video_bthwc: [B, T, H, W, 3] in [-1,1]
-    Returns latents with same B,T,H',W',C' as Wan expects.
-    """
-    # Try common Wan VAEs: model.vae.encode_video or model.vae.encode
-    vae = getattr(model, "vae", None)
-    if vae is None:
-        raise RuntimeError("WanModel has no .vae; please adapt encode path.")
+@torch.no_grad()
+def _norm_to_neg1_pos1(x: torch.Tensor) -> torch.Tensor:
+    # x uint8 [0,255] or float [0,1] -> float [-1,1]
+    if x.dtype in (torch.uint8, torch.int16, torch.int32, torch.int64):
+        x = x.float() / 255.0
+    return x.mul_(2.0).sub_(1.0)
 
-    # Prefer a vectorized encode if available
-    if hasattr(vae, "encode_video"):
-        return vae.encode_video(video_bthwc)  # type: ignore
 
-    if hasattr(vae, "encode"):
-        B, T, H, W, C = video_bthwc.shape
-        outs = []
-        for b in range(B):
-            per = []
-            for t in range(T):
-                img = video_bthwc[b, t].permute(2, 0, 1).unsqueeze(0)  # [1,3,H,W]
-                lat = vae.encode(img)  # [1,C',H',W'] (assumed)
-                per.append(lat)
-            outs.append(torch.stack(per, dim=1))  # [1,T,C',H',W']
-        return torch.cat(outs, dim=0)  # [B,T,C',H',W']
-    raise RuntimeError("Don't know how to encode latents; add your repo's method here.")
+@torch.no_grad()
+def encode_image_to_latents(vae, imgs: torch.Tensor) -> torch.Tensor:
+    # imgs: [B,3,H,W] in 0..1 or 0..255 -> [-1,1] -> [B,1,16,H/8,W/8]
+    imgs = _norm_to_neg1_pos1(imgs)
+    z = vae.encode(imgs)
+    return z
+
+
+@torch.no_grad()
+def encode_video_to_latents(vae, vids: torch.Tensor) -> torch.Tensor:
+    # vids: [B,T,3,H,W] -> [-1,1] -> [B,1+T/4,16,H/8,W/8]
+    vids = _norm_to_neg1_pos1(vids)
+    z = vae.encode(vids)
+    return z
+
+
+def parse_allowed_frames(arg: str) -> List[int]:
+    return [int(x) for x in arg.split(",") if x.strip()]
 
 
 def make_velocity_training_pair(
@@ -325,6 +338,9 @@ def main(args):
     _apply_filtered_state(model, state)
     model.requires_grad_(False)
 
+    # build/load VAE explicitly (Wan keeps it separate from the DiT)
+    vae = load_wan_vae(args.vae_ckpt or args.vae_dir, device=device, dtype=dtype)
+
     # Inject LoRA into cross-attn targets (default q/k/v/o)
     targets = tuple([s.strip() for s in args.targets.split(",") if s.strip()])
     inject_lora_kv(
@@ -364,7 +380,7 @@ def main(args):
     bridge = BridgeEncoderModel(text_len=args.text_len, device=device, dtype=dtype)
 
     # Data
-    frames = [int(x) for x in args.frames.split(",") if x.strip()]
+    frames = parse_allowed_frames(args.frames)
     reses = [int(x) for x in args.resolutions.split(",") if x.strip()]
     dataset = MixedCaptioned(
         root=args.data_root,
@@ -408,7 +424,7 @@ def main(args):
         for batch in loader:
             if step >= args.steps:
                 break
-            vids = batch["pixel"].permute(0, 1, 3, 4, 2).to(device)  # [B,T,H,W,3]
+            vids = batch["pixel"].to(device)  # [B,T,3,H,W]
             caps: List[str] = batch["caption"]
 
             # text → tokens → context
@@ -420,7 +436,7 @@ def main(args):
 
             # encode latents
             vids = vids.to(dtype=torch.float32)  # VAE usually wants fp32
-            x1 = encode_video_to_latents(model, vids)  # shape [B,T,C',H',W']
+            x1 = encode_video_to_latents(vae, vids)  # shape [B,1+T/4,16,H',W']
             x1 = x1.to(device=device, dtype=dtype)
 
             # flow-matching pair

--- a/wan_vae_loader.py
+++ b/wan_vae_loader.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+import importlib
+from pathlib import Path
+from typing import Optional
+import torch
+
+# We try a few common module paths used by Wan 2.x repos.
+CANDIDATES = [
+    ("inference.Wan2.2.wan.modules.vae.video_vae", "WanVAE", "from_pretrained"),
+    ("inference.Wan2.2.wan.modules.vae", "WanVAE", "from_pretrained"),
+    ("inference.Wan2.2.wan.modules.vae", "load_vae", None),
+    ("wan.modules.vae.video_vae", "WanVAE", "from_pretrained"),
+    ("wan.modules.vae", "WanVAE", "from_pretrained"),
+    ("wan.modules.vae", "load_vae", None),
+]
+
+
+def _maybe_find_vae_file(root: str | Path) -> Optional[str]:
+    root = Path(root)
+    if not root.exists():
+        return None
+    # look for common filenames
+    for name in ["vae.safetensors", "video_vae.safetensors", "wan_vae.safetensors"]:
+        p = root / name
+        if p.exists():
+            return str(p)
+    # last resort: the only .safetensors under root
+    ss = list(root.rglob("*.safetensors"))
+    return str(ss[0]) if ss else None
+
+
+def load_wan_vae(
+    vae_dir_or_ckpt: Optional[str], device: torch.device, dtype: torch.dtype
+):
+    """
+    Returns an object with a callable 'encode' that accepts:
+      - image tensor  [B,3,H,W] in [-1,1]  -> [B, 1, 16, H/8, W/8]
+      - video tensor  [B,T,3,H,W] in [-1,1] -> [B, 1+T/4, 16, H/8, W/8]
+    """
+    # Determine resource
+    ckpt = None
+    if vae_dir_or_ckpt:
+        p = Path(vae_dir_or_ckpt)
+        if p.is_file():
+            ckpt = str(p)
+        else:
+            ckpt = _maybe_find_vae_file(p)
+
+    # Try to import from repo
+    last_err = None
+    for mod_name, attr, ctor in CANDIDATES:
+        try:
+            m = importlib.import_module(mod_name)
+            obj = getattr(m, attr)
+            if callable(obj) and ctor is None:
+                vae = obj(ckpt or vae_dir_or_ckpt) if ckpt or vae_dir_or_ckpt else obj()
+            elif hasattr(obj, ctor or ""):
+                vae = (
+                    getattr(obj, ctor)(ckpt or vae_dir_or_ckpt)
+                    if ckpt or vae_dir_or_ckpt
+                    else getattr(obj, ctor)()
+                )
+            else:
+                vae = obj  # already an instance
+            # move / cast if methods exist
+            if hasattr(vae, "to"):
+                vae.to(device=device, dtype=dtype)
+            if hasattr(vae, "eval"):
+                vae.eval()
+            break
+        except Exception as e:
+            last_err = e
+            vae = None
+            continue
+
+    if vae is None:
+        raise RuntimeError(
+            f"Could not import Wan VAE. Last error: {last_err}\n"
+            f"Set --vae_dir to the Wan VAE folder or --vae_ckpt to its .safetensors."
+        )
+
+    class _Wrapper(torch.nn.Module):
+        def __init__(self, inner):
+            super().__init__()
+            self.inner = inner
+
+        @torch.no_grad()
+        def encode(self, x: torch.Tensor) -> torch.Tensor:
+            # Accept [B,3,H,W] or [B,T,3,H,W], values in [-1,1]
+            if x.dim() == 4:  # image
+                # common interfaces: encode returns either Tensor or a struct with .latent
+                if hasattr(self.inner, "encode"):
+                    y = self.inner.encode(x)
+                elif hasattr(self.inner, "forward"):
+                    y = self.inner(x)
+                else:
+                    raise RuntimeError("Wan VAE has no callable encode/forward")
+                return getattr(y, "latent", y)
+            elif x.dim() == 5:  # video
+                if hasattr(self.inner, "encode_video"):
+                    y = self.inner.encode_video(x)
+                    return getattr(y, "latent", y)
+                # fallback: run chunked along time using .encode
+                B, T, _, H, W = x.shape
+                outs = []
+                for t0 in range(0, T, 4):
+                    xt = x[:, t0 : t0 + 4]  # [B,<=4,3,H,W]
+                    xt = xt.reshape(-1, 3, H, W)  # merge time
+                    yt = self.encode(xt)  # [B*<=4, 1, 16, H/8, W/8]
+                    # reassemble with 3D causal compression (1 frame spatial-only, rest temporal 4x)
+                    outs.append(yt)
+                return torch.cat(outs, dim=1)
+            else:
+                raise ValueError(f"Unexpected input rank {x.dim()} for VAE.encode()")
+
+    return _Wrapper(vae)


### PR DESCRIPTION
## Summary
- load Wan VAE explicitly via new `wan_vae_loader` helper
- normalize image/video inputs in trainer and handle both with unified encode helpers
- make dataset frame selection robust and output [0,1] pixel values

## Testing
- `ruff check train_lora_stage_2.py mixed_media.py wan_vae_loader.py`
- `black train_lora_stage_2.py mixed_media.py wan_vae_loader.py`
- `pytest` *(fails: huggingface_hub.errors.HFValidationError: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/workspace/models/MythoMax-L2-13B')*


------
https://chatgpt.com/codex/tasks/task_e_68b286e31880832384206e1361681d1b