### PR TITLE
Enable visual LoRA injection for Wan 2.2 inference

### DIFF
--- a/inference/Wan2.2/generate.py
+++ b/inference/Wan2.2/generate.py
@@ -10,9 +10,15 @@ import random
 # Allow running without PYTHONPATH set to repo root
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 try:
-    from kv_lora_inject import inject_lora_kv, load_peft_adapter, LoRALinear
+    from kv_lora_inject import (
+        inject_lora_kv,
+        inject_lora_visual,
+        load_peft_adapter,
+        LoRALinear,
+    )
 except Exception:
     inject_lora_kv = None
+    inject_lora_visual = None
     load_peft_adapter = None
     LoRALinear = None
 
@@ -293,8 +299,8 @@ def _init_logging(rank):
         logging.basicConfig(level=logging.ERROR)
 
 
-def _maybe_load_kv_lora(pipeline, args, logger):
-    """Inject and load KV-LoRA into the Wan transformer inside the pipeline."""
+def _maybe_load_lora_adapter(pipeline, args, logger):
+    """Inject and load LoRA into the Wan transformer inside the pipeline."""
     if not args.lora_adapter_path:
         return
     if load_peft_adapter is None or inject_lora_kv is None:
@@ -305,8 +311,20 @@ def _maybe_load_kv_lora(pipeline, args, logger):
     target = (
         getattr(pipeline, "model", None) or getattr(pipeline, "dit", None) or pipeline
     )
-    # Inject LoRA stubs into cross-attn K/V and load PEFT-ish weights
+    # Inject LoRA stubs into cross-attn K/V
     inject_lora_kv(target, rank=8, alpha=args.lora_alpha)
+    # Also inject self-attention + FFN LoRA stubs so Stage-2/3 adapters load fully
+    try:
+        inject_lora_visual(
+            target,
+            rank=8,
+            alpha=args.lora_alpha,
+            enable_attn=True,
+            enable_ffn=True,
+        )
+    except Exception as e:
+        logger.warning(f"inject_lora_visual failed or unavailable: {e}")
+
     load_peft_adapter(
         target,
         path=args.lora_adapter_path,
@@ -314,7 +332,7 @@ def _maybe_load_kv_lora(pipeline, args, logger):
         alpha=args.lora_alpha,
     )
     logger.info(
-        f"Loaded KV-LoRA adapter: {args.lora_adapter_path} (prefix={args.lora_prefix})"
+        f"Loaded LoRA adapter: {args.lora_adapter_path} (prefix={args.lora_prefix})"
     )
 
 
@@ -423,7 +441,7 @@ def generate(args):
             t5_cpu=args.t5_cpu,
             convert_model_dtype=args.convert_model_dtype,
         )
-        _maybe_load_kv_lora(wan_t2v, args, logging)
+        _maybe_load_lora_adapter(wan_t2v, args, logging)
         if args.lora_adapter_path and LoRALinear is not None:
             target = (
                 getattr(wan_t2v, "model", None)
@@ -460,7 +478,7 @@ def generate(args):
             t5_cpu=args.t5_cpu,
             convert_model_dtype=args.convert_model_dtype,
         )
-        _maybe_load_kv_lora(wan_ti2v, args, logging)
+        _maybe_load_lora_adapter(wan_ti2v, args, logging)
         if args.lora_adapter_path and LoRALinear is not None:
             target = (
                 getattr(wan_ti2v, "model", None)
@@ -499,7 +517,7 @@ def generate(args):
             t5_cpu=args.t5_cpu,
             convert_model_dtype=args.convert_model_dtype,
         )
-        _maybe_load_kv_lora(wan_s2v, args, logging)
+        _maybe_load_lora_adapter(wan_s2v, args, logging)
         if args.lora_adapter_path and LoRALinear is not None:
             target = (
                 getattr(wan_s2v, "model", None)
@@ -541,7 +559,7 @@ def generate(args):
             t5_cpu=args.t5_cpu,
             convert_model_dtype=args.convert_model_dtype,
         )
-        _maybe_load_kv_lora(wan_i2v, args, logging)
+        _maybe_load_lora_adapter(wan_i2v, args, logging)
         if args.lora_adapter_path and LoRALinear is not None:
             target = (
                 getattr(wan_i2v, "model", None)

--- a/run_bikini_infer.sh
+++ b/run_bikini_infer.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Paths (edit if your layout differs) ---
+CKPT_DIR="/workspace/models/Wan2.2-TI2V-5B"           # base Wan checkpoints dir with diffusion_pytorch_model-*.safetensors
+ADAPTER_PATH="outputs/wan_lora_stage_3_visual/adapter_model.safetensors"  # latest exported adapter
+BRIDGE_CKPT="outputs/encoder_bridge_thesby/bridge_step010000-affine.pth"  # your trained bridge
+LLM_DIR="thesby/Qwen2.5-VL-7B-NSFW-Caption-V3"                              # your local/HF path
+
+# --- Bridge envs ---
+export WAN_USE_BRIDGE=1
+export WAN_BRIDGE_CKPT="${BRIDGE_CKPT}"
+export WAN_BRIDGE_LLM_DIR="${LLM_DIR}"
+export WAN_BRIDGE_DTYPE="bf16"        # set to "fp16" if your GPU lacks bf16
+export WAN_BRIDGE_FORCE_VL=1
+export WAN_BRIDGE_GLOBAL_SCALE="1.0"
+
+# --- Prompt (safe, adult-only wording) ---
+PROMPT="A photorealistic portrait of an adult woman wearing a stylish bikini on a sunny beach; confident pose, natural skin, detailed lighting, cinematic color grading, tasteful; no nudity, no minors."
+
+# --- Sampler settings ---
+TASK="ti2v-5B"
+SIZE="1280*704"        # ti2v-5B supports: 704*1280 or 1280*704
+FRAMES=1               # single-frame still (must be 4n+1 -> 1 is valid)
+STEPS=50
+GUIDE=5.5              # CFG (try 4.5, 5.5, 6.5)
+SEED=12345
+
+OUT_DIR="outputs/infer"
+mkdir -p "${OUT_DIR}"
+OUT="${OUT_DIR}/bikini_${TASK}_${SIZE}_s${SEED}_st${STEPS}_cfg${GUIDE}.mp4"
+
+# --- Run ---
+python inference/Wan2.2/generate.py \
+  --task "${TASK}" \
+  --ckpt_dir "${CKPT_DIR}" \
+  --size "${SIZE}" \
+  --frame_num ${FRAMES} \
+  --sample_solver "unipc" \
+  --sample_steps ${STEPS} \
+  --sample_guide_scale ${GUIDE} \
+  --base_seed ${SEED} \
+  --lora_adapter_path "${ADAPTER_PATH}" \
+  --lora_alpha 32 \
+  --lora_prefix "diffusion_model." \
+  --save_file "${OUT}" \
+  --prompt "${PROMPT}"
+
+echo "Saved: ${OUT}"


### PR DESCRIPTION
## Summary
- Load visual LoRA stubs alongside KV so Stage-2/3 adapters apply fully
- Rename helper to `_maybe_load_lora_adapter` and use it across inference paths
- Add `run_bikini_infer.sh` sample for bridge-enabled TI2V inference

## Testing
- `python -m black inference/Wan2.2/generate.py`
- `ruff check inference/Wan2.2/generate.py`
- `pytest` *(fails: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/workspace/models/MythoMax-L2-13B')*
- `./run_bikini_infer.sh` *(fails: RuntimeError: Found no NVIDIA driver on your system)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f21a257c8323b84530bafef9b51a